### PR TITLE
Replace withColumn with withColumns in data quality templates

### DIFF
--- a/src/lhp/templates/transform/data_quality.py.j2
+++ b/src/lhp/templates/transform/data_quality.py.j2
@@ -21,9 +21,11 @@ def {{ target_view }}():
     {% if add_operational_metadata %}
     
     # Add operational metadata columns
-    {% for col_name, expression in metadata_columns.items()|sort %}
-    df = df.withColumn('{{ col_name }}', {{ expression }})
-    {% endfor %}
+    df = df.withColumns({
+        {%- for col_name, expression in metadata_columns.items()|sort %}
+        '{{ col_name }}': {{ expression }}{{ "," if not loop.last }}
+        {%- endfor %}
+    })
     {% endif %}
     
     return df

--- a/src/lhp/templates/transform/data_quality_quarantine.py.j2
+++ b/src/lhp/templates/transform/data_quality_quarantine.py.j2
@@ -53,10 +53,12 @@ def dlq_sink_{{ safe_source_view }}(batch_df, batch_id):
 
     batch = (
         batch_df
-        .withColumn("_row_json", F.to_json(F.struct(*hash_cols)))
-        .withColumn("_dlq_sk", F.xxhash64(
-            F.lit(SOURCE_TABLE_{{ safe_source_view }}), F.col("_row_json")
-        ).cast("string"))
+        .withColumns({
+            "_row_json": F.to_json(F.struct(*hash_cols)),
+            "_dlq_sk": F.xxhash64(
+                F.lit(SOURCE_TABLE_{{ safe_source_view }}), F.to_json(F.struct(*hash_cols))
+            ).cast("string"),
+        })
     )
 
     if "_rescued_data" in batch_df.columns:
@@ -64,8 +66,8 @@ def dlq_sink_{{ safe_source_view }}(batch_df, batch_id):
         variant_cols = [c for c in data_cols if c != "_rescued_data"]
         batch = (
             batch
-            .withColumn("_variant_json",
-                F.when(
+            .withColumns({
+                "_variant_json": F.when(
                     F.col("_rescued_data").isNotNull(),
                     F.to_json(
                         F.map_zip_with(
@@ -77,23 +79,29 @@ def dlq_sink_{{ safe_source_view }}(batch_df, batch_id):
                             lambda k, v1, v2: F.coalesce(v2, v1),
                         )
                     ),
-                ).otherwise(F.to_json(F.struct(*variant_cols)))
-            )
-            .withColumn("_row_data", F.parse_json(F.col("_variant_json")))
+                ).otherwise(F.to_json(F.struct(*variant_cols))),
+            })
+            .withColumns({
+                "_row_data": F.parse_json(F.col("_variant_json")),
+            })
             .withColumnRenamed("_rescued_data", "_dlq_rescued_data")
         )
     else:
         batch = (
             batch
-            .withColumn("_row_data", F.parse_json(F.to_json(F.struct(*data_cols))))
-            .withColumn("_dlq_rescued_data", F.lit(None).cast("string"))
+            .withColumns({
+                "_row_data": F.parse_json(F.to_json(F.struct(*data_cols))),
+                "_dlq_rescued_data": F.lit(None).cast("string"),
+            })
         )
 
     batch = (
         batch
-        .withColumn("_dlq_source_table", F.lit(SOURCE_TABLE_{{ safe_source_view }}))
-        .withColumn("_dlq_status", F.lit("quarantined"))
-        .withColumn("_dlq_timestamp", F.current_timestamp())
+        .withColumns({
+            "_dlq_source_table": F.lit(SOURCE_TABLE_{{ safe_source_view }}),
+            "_dlq_status": F.lit("quarantined"),
+            "_dlq_timestamp": F.current_timestamp(),
+        })
         .select(
             "_dlq_sk", "_dlq_source_table", "_dlq_status",
             "_dlq_timestamp", "_dlq_failed_rules", "_dlq_rescued_data",
@@ -197,9 +205,11 @@ def {{ target_view }}():
     {% if add_operational_metadata %}
 
     # Add operational metadata columns
-    {% for col_name, expression in metadata_columns.items()|sort %}
-    df = df.withColumn('{{ col_name }}', {{ expression }})
-    {% endfor %}
+    df = df.withColumns({
+        {%- for col_name, expression in metadata_columns.items()|sort %}
+        '{{ col_name }}': {{ expression }}{{ "," if not loop.last }}
+        {%- endfor %}
+    })
     {% endif %}
 
     return df


### PR DESCRIPTION
## Summary
- Replaces repeated `withColumn` calls with single `withColumns` dict calls in `data_quality.py.j2` and `data_quality_quarantine.py.j2`
- Batches independent column additions into single `withColumns` calls for better Spark performance
- Fixes the Jinja loop pattern to emit a dict instead of sequential reassignments

Fixes #92

## Test plan
- [ ] Verify generated Python from `data_quality.py.j2` uses `withColumns({...})` syntax
- [ ] Verify generated Python from `data_quality_quarantine.py.j2` uses `withColumns({...})` in all applicable spots
- [ ] Run existing unit/e2e tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)