### PR TITLE
Fix liccheck: add setuptools and replace process substitution

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -85,11 +85,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools
           pip install -e .
           pip install liccheck
 
       - name: Check license compliance
-        run: liccheck -s liccheck.ini -r <(pip freeze)
+        run: |
+          pip freeze > requirements-frozen.txt
+          liccheck -s liccheck.ini -r requirements-frozen.txt
 
   gitleaks:
     name: Secret Scanning


### PR DESCRIPTION
## Summary

- Install `setuptools` explicitly — `liccheck` imports `pkg_resources` which was removed from Python 3.12+ default installs
- Replace `<(pip freeze)` with a temp file — process substitution requires bash but GitHub Actions defaults to sh

## Test plan

- [x] License Compliance job should pass without `ModuleNotFoundError: No module named 'pkg_resources'`