### PR TITLE
V0.8.3: monitoring race fix + dedicated monitoring.job_config_path

### DIFF
--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -128,11 +128,13 @@ Get centralized pipeline monitoring in three steps:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 .. tip::
-   ``checkpoint_path`` is the only required field under ``monitoring``. Everything else
-   has sensible defaults: the pipeline is named ``${project_name}_event_log_monitoring``,
-   uses the same catalog/schema as ``event_log``, creates a Delta table called
+   ``checkpoint_path`` and ``job_config_path`` are the only required fields under
+   ``monitoring``. Everything else has sensible defaults: the pipeline is named
+   ``${project_name}_event_log_monitoring``, uses the same catalog/schema as
+   ``event_log``, creates a Delta table called
    ``all_pipelines_event_log``, and exposes a default ``events_summary`` materialized view
    that summarizes pipeline run status, duration, and row metrics.
 
@@ -332,6 +334,22 @@ Workflow job that chains them.
    ``LHP-CFG-008`` if it is missing. Prior releases accepted ``monitoring: {}`` — that
    form is no longer valid.
 
+.. warning::
+   ``job_config_path`` is **required** when ``monitoring.enabled`` is ``true``. It must
+   point (relative to the project root) to a flat single-document YAML file describing
+   the monitoring Workflow job (cluster, tags, notifications, schedule, etc.). LHP
+   raises ``LHP-CFG-008`` if the setting is missing and ``LHP-IO-001`` if the configured
+   path does not resolve to an existing file. Token substitution (``${...}``) applies to
+   the file contents, resolved from the active environment's
+   ``substitutions/<env>.yaml``.
+
+.. note::
+   The legacy auto-pickup of ``templates/bundle/job_config.yaml`` for the monitoring
+   job — and the reserved ``__eventlog_monitoring`` alias inside it — has been
+   **removed**. The ``__eventlog_monitoring`` alias still works in the generic
+   ``config/job_config.yaml`` used by ``lhp deps`` to customize *orchestration* jobs;
+   that surface is unchanged.
+
 Configuration Reference
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -356,6 +374,18 @@ Configuration Reference
        ``{checkpoint_path}/{pipeline_name}/``. Typically a Unity Catalog volume path
        (e.g., ``/Volumes/my_catalog/_meta/checkpoints/event_logs``). Supports LHP token
        substitution.
+   * - ``job_config_path``
+     - string
+     - **required**
+     - Relative path (from the project root) to a dedicated YAML file describing the
+       generated monitoring Workflow job (cluster, tags, notifications, schedule,
+       permissions, …). Flat single-document mapping — no ``project_defaults:`` wrapper
+       and no ``job_name:`` key. Contents are deep-merged over LHP's default job config
+       (``max_concurrent_runs=1``, ``performance_target=STANDARD``, ``queue.enabled=true``)
+       and then token-substituted via the active env's ``substitutions/<env>.yaml``.
+       ``lhp init`` scaffolds ``config/monitoring_job_config_env.yaml.tmpl`` — rename it
+       to ``config/monitoring_job_config.yaml`` (or your preferred path) and point
+       ``job_config_path`` at it.
    * - ``max_concurrent_streams``
      - integer
      - ``10``
@@ -400,7 +430,8 @@ Configuration Reference
 Minimal Configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
-The simplest valid monitoring configuration specifies just the checkpoint path:
+The simplest valid monitoring configuration specifies the checkpoint path and the
+path to the dedicated monitoring-job config file:
 
 .. code-block:: yaml
    :caption: lhp.yaml
@@ -412,6 +443,7 @@ The simplest valid monitoring configuration specifies just the checkpoint path:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 This creates:
 
@@ -432,6 +464,7 @@ Custom Pipeline Name
    monitoring:
      pipeline_name: "my_custom_monitor"
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 The pipeline name affects:
 
@@ -459,6 +492,7 @@ in ``event_log``. You can override either or both:
      catalog: "analytics_cat"
      schema: "_analytics"
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 **Override priority:**
 
@@ -496,6 +530,26 @@ with its own checkpoint directory.
        ("gold_analytics",  "acme_edw_dev._meta.gold_analytics_event_log"),
    ]
 
+   def _ensure_target_exists() -> None:
+       # Pre-create TARGET_TABLE (idempotent) so parallel streams do not race
+       # on CREATE during a cold run.
+       if spark.catalog.tableExists(TARGET_TABLE):
+           return
+       for sample_name, sample_ref in SOURCES:
+           try:
+               empty = (
+                   spark.read.format("delta").table(sample_ref).limit(0)
+                   .withColumn("_source_pipeline", F.lit(sample_name))
+               )
+               empty.write.format("delta").saveAsTable(TARGET_TABLE)
+               return
+           except AnalysisException:
+               continue
+       raise RuntimeError("no readable source event log")
+
+   if SOURCES:
+       _ensure_target_exists()
+
    def process_source(pipeline_name: str, table_ref: str) -> str:
        checkpoint = f"{CHECKPOINT_BASE}/{pipeline_name}"
        query = (
@@ -519,6 +573,15 @@ with its own checkpoint directory.
 
 Key aspects:
 
+* **Pre-created target table.** Before launching the executor pool,
+  ``_ensure_target_exists()`` pre-creates the target Delta table using the schema
+  of the first readable source event log (event-log schemas are uniform across
+  Lakeflow Declarative Pipelines). Without this prologue, N parallel streams all
+  race to ``CREATE`` the target via ``.toTable()`` on a cold run; one wins, the
+  rest fail with ``TABLE_OR_VIEW_ALREADY_EXISTS``. The function is idempotent —
+  warm runs short-circuit via ``spark.catalog.tableExists`` — and iterates through
+  ``SOURCES`` until one event log is readable, so partially-deployed environments
+  still bootstrap cleanly.
 * **Per-pipeline checkpoints.** Each source has its own directory at
   ``{CHECKPOINT_BASE}/{pipeline_name}/``. Changing the set of sources never invalidates
   existing checkpoints.
@@ -753,6 +816,7 @@ Define materialized views with inline SQL using the ``sql`` property:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
      materialized_views:
        - name: "error_events"
          sql: "SELECT * FROM all_pipelines_event_log WHERE event_type = 'error'"
@@ -798,6 +862,7 @@ For complex queries, use ``sql_path`` to reference an external SQL file:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
      materialized_views:
        - name: "custom_analysis"
          sql_path: "sql/monitoring_custom_analysis.sql"
@@ -828,6 +893,7 @@ To generate only the notebook and the notebook task of the job, set
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
      materialized_views: []
 
 When omitted entirely (or set to ``null``), the default ``events_summary`` MV is created.
@@ -862,27 +928,17 @@ Violations raise ``LHP-CFG-008`` with a descriptive error message.
 Customizing the Workflow Job
 ----------------------------
 
-The generated Workflow job resource can be customized from ``config/job_config.yaml``.
-LHP provides a reserved alias so you do not need to hardcode the monitoring job name.
-
-Using the __eventlog_monitoring Alias in job_config.yaml
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use the ``__eventlog_monitoring`` reserved keyword as a job name in
-``config/job_config.yaml`` to target the monitoring job without hardcoding its generated
-name.
+The generated Workflow job is configured from a **dedicated** YAML file referenced by
+``monitoring.job_config_path`` in ``lhp.yaml``. This file is required when monitoring
+is enabled.
 
 .. code-block:: yaml
-   :caption: config/job_config.yaml
+   :caption: config/monitoring_job_config.yaml
 
-   project_defaults:
-     max_concurrent_runs: 1
-     performance_target: STANDARD
-
-   ---
-   job_name: __eventlog_monitoring
    max_concurrent_runs: 1
    performance_target: PERFORMANCE_OPTIMIZED
+   queue:
+     enabled: true
    timeout_seconds: 3600
    notebook_cluster:
      new_cluster:
@@ -896,12 +952,22 @@ name.
    tags:
      purpose: event_log_monitoring
      team: data-platform
+     environment: ${bundle_target}
    email_notifications:
      on_failure:
        - monitoring-alerts@company.com
 
-At generation time, ``__eventlog_monitoring`` resolves to the actual monitoring job
-name (``${pipeline_name}_job``). ``project_defaults`` still merges in as usual.
+How it is resolved:
+
+1. LHP reads the file at ``project_root / monitoring.job_config_path``.
+2. Token substitution (``${...}``) is applied using the active environment's
+   ``substitutions/<env>.yaml``.
+3. The result is deep-merged over LHP's default job config
+   (``max_concurrent_runs=1``, ``performance_target=STANDARD``, ``queue.enabled=true``)
+   — nested dicts like ``tags`` and ``queue`` merge recursively; lists are replaced
+   wholesale.
+4. The monitoring job name is always ``${pipeline_name}_job``. Do **not** add a
+   ``job_name`` key to this file.
 
 Available job fields (all optional):
 
@@ -918,12 +984,19 @@ Available job fields (all optional):
 Rules
 ~~~~~
 
-* If monitoring is **not configured or disabled** in ``lhp.yaml``, the alias entry is
-  silently ignored with a warning.
-* If **both** the alias and the resolved monitoring job name appear in the config, LHP
-  raises an error.
+* The file must be a **flat single-document YAML mapping**. Do not wrap it in a
+  ``project_defaults:`` key and do not add a ``job_name:`` key.
 * The ``pipeline_task`` in the job is always generated automatically — do not redefine
-  it in ``job_config.yaml``.
+  it in this file.
+* If the file is missing at generation time, LHP raises ``LHP-IO-001`` pointing to the
+  resolved absolute path.
+
+.. note::
+   The legacy auto-pickup of ``templates/bundle/job_config.yaml`` for the monitoring
+   job — and the reserved ``__eventlog_monitoring`` alias inside it — has been
+   **removed**. Use ``monitoring.job_config_path`` instead. The ``__eventlog_monitoring``
+   alias continues to work in the generic ``config/job_config.yaml`` used by
+   ``lhp deps`` for *orchestration* jobs; that surface is unchanged.
 
 Pipeline Configuration for Monitoring
 --------------------------------------
@@ -1008,6 +1081,7 @@ pipeline runs using the Databricks SDK. The results are written to a separate
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
      enable_job_monitoring: true
 
 **What it generates:**
@@ -1123,6 +1197,7 @@ The simplest possible monitoring configuration:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 This gives you:
 
@@ -1155,6 +1230,7 @@ A fully customized monitoring setup:
      schema: "_monitoring"
      streaming_table: "unified_event_stream"
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
      max_concurrent_streams: 20
      materialized_views:
        - name: "error_events"
@@ -1183,6 +1259,7 @@ to opt individual pipelines out:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 .. code-block:: yaml
    :caption: config/pipeline_config.yaml — opt out specific pipelines
@@ -1213,6 +1290,7 @@ Use LHP substitution tokens for environment-aware monitoring:
 
    monitoring:
      checkpoint_path: "/Volumes/${catalog}/${monitoring_schema}/checkpoints/event_logs"
+     job_config_path: "config/monitoring_job_config.yaml"
 
 .. code-block:: yaml
    :caption: substitutions/dev.yaml
@@ -1249,11 +1327,18 @@ Migration steps:
 
 1. **Add ``checkpoint_path``** to your ``monitoring`` block (now required — typically a
    Unity Catalog volume path).
-2. **Re-run ``lhp generate``.** LHP will clean up the old single-pipeline artifacts and
+2. **Add ``job_config_path``** to your ``monitoring`` block (now required). Create the
+   file it points to — ``lhp init`` scaffolds
+   ``config/monitoring_job_config_env.yaml.tmpl`` as a starting point. If you previously
+   used the ``__eventlog_monitoring`` alias inside ``templates/bundle/job_config.yaml``
+   for the monitoring job, move those settings into the new dedicated file and drop the
+   ``job_name: __eventlog_monitoring`` wrapper plus the ``project_defaults:`` wrapper —
+   the monitoring config is a flat single-document mapping.
+3. **Re-run ``lhp generate``.** LHP will clean up the old single-pipeline artifacts and
    write the new notebook, MVs-only pipeline, and job resource.
-3. **Redeploy via Databricks Asset Bundles.** The old pipeline is removed by the bundle
+4. **Redeploy via Databricks Asset Bundles.** The old pipeline is removed by the bundle
    deploy; the new job and (MVs-only) pipeline are deployed in its place.
-4. **Backfill the union Delta table** if needed. Historical event log rows written before
+5. **Backfill the union Delta table** if needed. Historical event log rows written before
    the new notebook's first run are not replayed into the union table unless you manually
    run a one-off backfill from each event log table.
 
@@ -1268,6 +1353,16 @@ Common issues:
 
 * **``LHP-CFG-008`` — "Monitoring checkpoint_path is required"** — add
   ``checkpoint_path`` under ``monitoring`` or set ``monitoring.enabled: false``.
+* **``LHP-CFG-008`` — "Monitoring job_config_path is required"** — add
+  ``job_config_path`` under ``monitoring`` pointing to your dedicated monitoring job
+  config file, or set ``monitoring.enabled: false``.
+* **``LHP-CFG-008`` — "Monitoring job_config file not found"** — the file referenced by
+  ``job_config_path`` does not exist. Check the path (resolved relative to project root)
+  and create the file if needed. ``lhp init`` provides
+  ``config/monitoring_job_config_env.yaml.tmpl`` as a starter.
+* **``LHP-IO-001`` — "Monitoring job_config file not found"** — raised at generate time
+  when the configured ``job_config_path`` cannot be opened. The error message includes
+  the resolved absolute path.
 * **No rows in ``all_pipelines_event_log``** — check that the Workflow job has run
   successfully. The notebook writes via Structured Streaming; the Delta table is created
   on first successful write.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lakehouse-plumber"
-version = "0.8.2"
+version = "0.8.3"
 description = "A framework for building and managing enterprise Lakeflow Spark Declaritive Pipelines"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/lhp/core/orchestrator.py
+++ b/src/lhp/core/orchestrator.py
@@ -643,14 +643,94 @@ class ActionOrchestrator:
         smart_writer.write_if_changed(notebook_path, notebook_content)
         self.logger.info(f"Generated monitoring notebook: {notebook_path}")
 
-        # 6. Generate and write monitoring job resource
+        # 6. Load + substitute + merge monitoring job config from the dedicated file
+        import yaml
+
         from .services.job_generator import JobGenerator
 
-        job_name = f"{monitoring_pipeline_name}_job"
-        job_gen = JobGenerator(
-            project_root=self.project_root,
-            monitoring_job_name=job_name,
+        raw_job_config_rel_path = self.project_config.monitoring.job_config_path
+        # Substitute tokens (e.g. ${env}) in the path. The loader only checks
+        # file existence for static paths; tokenized paths are resolved here
+        # once the environment is known.
+        job_config_rel_path = (
+            substitution_mgr.substitute_yaml(raw_job_config_rel_path)
+            if raw_job_config_rel_path
+            else raw_job_config_rel_path
         )
+        # Presence + (static-path) existence are guaranteed by ProjectConfigLoader
+        # validation, but we keep a defensive check here because orchestration
+        # also runs through code paths that bypass the loader's validation (tests)
+        # and tokenized paths only resolve at this stage.
+        if not job_config_rel_path:
+            raise LHPError(
+                category=ErrorCategory.CONFIG,
+                code_number="008",
+                title="Monitoring job_config_path is required",
+                details=(
+                    "monitoring.job_config_path must be set when monitoring is enabled."
+                ),
+                suggestions=[
+                    "Add job_config_path to your monitoring config in lhp.yaml",
+                    "Example: job_config_path: config/monitoring_job_config.yaml",
+                ],
+            )
+
+        job_config_file = self.project_root / job_config_rel_path
+        if not job_config_file.is_file():
+            raise LHPFileError(
+                category=ErrorCategory.IO,
+                code_number="001",
+                title="Monitoring job_config file not found",
+                details=(
+                    f"monitoring.job_config_path points to '{job_config_rel_path}', "
+                    f"but no file exists at {job_config_file}."
+                ),
+                suggestions=[
+                    "Create the file at the configured path",
+                    "Or update monitoring.job_config_path to a valid location",
+                ],
+                context={
+                    "File Path": str(job_config_rel_path),
+                    "Project Root": str(self.project_root),
+                },
+            )
+
+        try:
+            with open(job_config_file, "r", encoding="utf-8") as f:
+                raw_job_config = yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            raise LHPFileError(
+                category=ErrorCategory.IO,
+                code_number="002",
+                title="Invalid monitoring job_config YAML",
+                details=f"Failed to parse {job_config_file}: {e}",
+                suggestions=["Fix the YAML syntax in the monitoring job config"],
+                context={"File Path": str(job_config_file)},
+            )
+
+        if not isinstance(raw_job_config, dict):
+            raise LHPError(
+                category=ErrorCategory.CONFIG,
+                code_number="008",
+                title="Invalid monitoring job_config structure",
+                details=(
+                    f"{job_config_file} must contain a YAML mapping at the top level, "
+                    f"got {type(raw_job_config).__name__}."
+                ),
+                suggestions=[
+                    "Use a flat single-document mapping (no 'project_defaults' wrapper, "
+                    "no 'job_name' key)",
+                ],
+            )
+
+        substituted_job_config = substitution_mgr.substitute_yaml(raw_job_config)
+        resolved_job_config = JobGenerator.resolve_monitoring_job_config(
+            substituted_job_config
+        )
+
+        # 7. Generate and write monitoring job resource
+        job_name = f"{monitoring_pipeline_name}_job"
+        job_gen = JobGenerator(project_root=self.project_root)
         notebook_workspace_path = (
             "${workspace.file_path}/monitoring/${bundle.target}/union_event_logs"
         )
@@ -659,6 +739,7 @@ class ActionOrchestrator:
             pipeline_name=monitoring_pipeline_name,
             notebook_path=notebook_workspace_path,
             job_name=job_name,
+            job_config=resolved_job_config,
             has_pipeline=has_pipeline,
         )
         resources_dir = self.project_root / "resources"

--- a/src/lhp/core/project_config_loader.py
+++ b/src/lhp/core/project_config_loader.py
@@ -4,8 +4,11 @@ Loads project-level configuration from lhp.yaml including operational metadata d
 """
 
 import logging
+import re
 from pathlib import Path
 from typing import Optional, Dict, Any, List
+
+_SUBSTITUTION_TOKEN_PATTERN = re.compile(r"\$\{[^}]+\}")
 
 from ..models.config import (
     EventLogConfig,
@@ -376,6 +379,7 @@ class ProjectConfigLoader:
                     "streaming_table", "all_pipelines_event_log"
                 ),
                 checkpoint_path=monitoring_data.get("checkpoint_path", ""),
+                job_config_path=monitoring_data.get("job_config_path"),
                 max_concurrent_streams=monitoring_data.get(
                     "max_concurrent_streams", 10
                 ),
@@ -472,6 +476,8 @@ class ProjectConfigLoader:
 
         Checks:
         - If enabled, event_log must be present and enabled
+        - If enabled, checkpoint_path must be set
+        - If enabled, job_config_path must be set and point to an existing file
         - MV names must be unique
         - MVs must not specify both sql and sql_path
 
@@ -518,6 +524,47 @@ class ProjectConfigLoader:
                     "/Volumes/catalog/schema/checkpoints/event_logs",
                 ],
             )
+
+        # job_config_path is required when monitoring is enabled
+        if not config.job_config_path:
+            raise LHPError(
+                category=ErrorCategory.CONFIG,
+                code_number="008",
+                title="Monitoring job_config_path is required",
+                details=(
+                    "monitoring.job_config_path must be set when monitoring is enabled. "
+                    "It points to a dedicated YAML file describing the monitoring "
+                    "workflow job (cluster, tags, notifications, schedule, etc.)."
+                ),
+                suggestions=[
+                    "Add job_config_path to your monitoring config in lhp.yaml",
+                    "Example:\n  monitoring:\n    job_config_path: "
+                    "config/monitoring_job_config.yaml",
+                    "Run 'lhp init <project>' to scaffold a starter config file",
+                ],
+            )
+
+        # Defer the existence check when the path contains substitution tokens
+        # (e.g. ${env}). Tokens can only be resolved once the CLI selects an
+        # environment — orchestrator.finalize_monitoring_artifacts re-checks
+        # existence after substitution.
+        if not _SUBSTITUTION_TOKEN_PATTERN.search(config.job_config_path):
+            job_config_file = self.project_root / config.job_config_path
+            if not job_config_file.is_file():
+                raise LHPError(
+                    category=ErrorCategory.CONFIG,
+                    code_number="008",
+                    title="Monitoring job_config file not found",
+                    details=(
+                        f"monitoring.job_config_path points to '{config.job_config_path}', "
+                        f"but no file exists at {job_config_file}."
+                    ),
+                    suggestions=[
+                        "Create the file at the configured path",
+                        "Or update monitoring.job_config_path to a valid location",
+                        "Paths are resolved relative to the project root",
+                    ],
+                )
 
         # Validate materialized views
         if config.materialized_views:

--- a/src/lhp/core/services/job_generator.py
+++ b/src/lhp/core/services/job_generator.py
@@ -56,15 +56,11 @@ class JobGenerator:
         "master_job_name": None,  # Custom master job name (None = auto-generate)
     }
 
-    # Alias for monitoring job in job_config.yaml (same pattern as PipelineConfigLoader)
-    MONITORING_JOB_ALIAS = "__eventlog_monitoring"
-
     def __init__(
         self,
         template_dir: Optional[Path] = None,
         project_root: Optional[Path] = None,
         config_file_path: Optional[str] = None,
-        monitoring_job_name: Optional[str] = None,
     ):
         """
         Initialize the job generator.
@@ -73,10 +69,7 @@ class JobGenerator:
             template_dir: Directory containing Jinja2 templates. If None, uses default.
             project_root: Root directory of the project for loading custom config.
             config_file_path: Custom config file path (relative to project_root).
-            monitoring_job_name: Resolved monitoring job name for alias support.
         """
-        self.monitoring_job_name = monitoring_job_name
-
         if template_dir is None:
             # Default to the templates directory in the package
             template_dir = Path(__file__).parent.parent.parent / "templates"
@@ -92,7 +85,7 @@ class JobGenerator:
         )
         self.logger = logger
 
-        # Load and merge job configuration
+        # Load and merge job configuration (used by the `deps` orchestration-job flow)
         self.project_defaults, self.job_specific_configs = self._load_job_config(
             project_root, config_file_path
         )
@@ -100,9 +93,6 @@ class JobGenerator:
         self.job_config = self._deep_merge_dicts(
             self.DEFAULT_JOB_CONFIG.copy(), self.project_defaults
         )
-
-        # Resolve monitoring job alias after loading config
-        self._resolve_monitoring_alias()
 
     def _load_job_config(
         self,
@@ -294,8 +284,9 @@ class JobGenerator:
             )
             raise
 
+    @staticmethod
     def _deep_merge_dicts(
-        self, base: Dict[str, Any], override: Dict[str, Any]
+        base: Dict[str, Any], override: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
         Deep merge two dictionaries. Nested dicts are merged recursively, lists are replaced.
@@ -316,7 +307,7 @@ class JobGenerator:
                 and isinstance(value, dict)
             ):
                 # Recursively merge nested dicts
-                result[key] = self._deep_merge_dicts(result[key], value)
+                result[key] = JobGenerator._deep_merge_dicts(result[key], value)
             else:
                 # Replace value (including lists)
                 result[key] = value
@@ -750,59 +741,14 @@ class JobGenerator:
 
     # ---- Monitoring job support ----
 
-    def _resolve_monitoring_alias(self) -> None:
-        """Resolve __eventlog_monitoring alias to actual monitoring job name.
-
-        Same pattern as PipelineConfigLoader._resolve_monitoring_alias():
-        - If alias not in job_specific_configs: return
-        - If monitoring_job_name is None: warn and remove
-        - If actual name already exists: raise collision error
-        - Otherwise: rename alias key to actual name
-        """
-        if self.MONITORING_JOB_ALIAS not in self.job_specific_configs:
-            return
-
-        if self.monitoring_job_name is None:
-            self.logger.warning(
-                f"'{self.MONITORING_JOB_ALIAS}' found in job config but monitoring "
-                f"is not configured or enabled. Ignoring this entry."
-            )
-            del self.job_specific_configs[self.MONITORING_JOB_ALIAS]
-            return
-
-        if self.monitoring_job_name in self.job_specific_configs:
-            raise LHPValidationError(
-                category=ErrorCategory.VALIDATION,
-                code_number="010",
-                title="Duplicate monitoring job configuration",
-                details=(
-                    f"Both '{self.MONITORING_JOB_ALIAS}' alias and the actual monitoring job "
-                    f"name '{self.monitoring_job_name}' are defined in job config. "
-                    f"Use one or the other, not both."
-                ),
-                suggestions=[
-                    f"Remove either the '{self.MONITORING_JOB_ALIAS}' entry or the "
-                    f"'{self.monitoring_job_name}' entry",
-                    f"The '{self.MONITORING_JOB_ALIAS}' alias automatically resolves to "
-                    f"'{self.monitoring_job_name}'",
-                ],
-                context={
-                    "Alias": self.MONITORING_JOB_ALIAS,
-                    "Actual Name": self.monitoring_job_name,
-                },
-            )
-
-        config = self.job_specific_configs.pop(self.MONITORING_JOB_ALIAS)
-        self.job_specific_configs[self.monitoring_job_name] = config
-        self.logger.debug(
-            f"Resolved '{self.MONITORING_JOB_ALIAS}' alias to '{self.monitoring_job_name}'"
-        )
+    
 
     def generate_monitoring_job(
         self,
         pipeline_name: str,
         notebook_path: str,
-        job_name: Optional[str] = None,
+        job_name: str,
+        job_config: Dict[str, Any],
         has_pipeline: bool = True,
     ) -> str:
         """Generate monitoring job YAML (notebook_task → optional pipeline_task).
@@ -810,17 +756,15 @@ class JobGenerator:
         Args:
             pipeline_name: Name of the monitoring DLT pipeline
             notebook_path: Workspace path to the union event logs notebook
-            job_name: Custom job name (defaults to monitoring_job_name or pipeline_name + "_job")
+            job_name: Resolved monitoring job name
+            job_config: Resolved monitoring job config (already merged with defaults
+                and substituted). The caller is responsible for building this dict —
+                typically via ``JobGenerator.resolve_monitoring_job_config``.
             has_pipeline: Whether a DLT pipeline exists (False = notebook-only job)
 
         Returns:
             Rendered YAML string for the monitoring job resource
         """
-        if not job_name:
-            job_name = self.monitoring_job_name or f"{pipeline_name}_job"
-
-        job_config = self.get_job_config_for_job(job_name)
-
         context = {
             "job_name": job_name,
             "pipeline_name": pipeline_name,
@@ -837,3 +781,22 @@ class JobGenerator:
         except Exception as e:
             self.logger.error(f"Failed to render monitoring job template: {e}")
             raise
+
+    @classmethod
+    def resolve_monitoring_job_config(
+        cls, raw_config: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Deep-merge a raw monitoring job config dict over ``DEFAULT_JOB_CONFIG``.
+
+        This keeps merge semantics inside the class that owns ``DEFAULT_JOB_CONFIG``
+        and is used by the orchestrator to build the per-generate monitoring job
+        config from the dedicated YAML file referenced by
+        ``monitoring.job_config_path``.
+
+        Args:
+            raw_config: Parsed monitoring job config (post token substitution).
+
+        Returns:
+            Merged config dict ready to hand to ``generate_monitoring_job``.
+        """
+        return cls._deep_merge_dicts(cls.DEFAULT_JOB_CONFIG.copy(), raw_config or {})

--- a/src/lhp/models/config.py
+++ b/src/lhp/models/config.py
@@ -154,6 +154,7 @@ class MonitoringConfig(BaseModel):
     schema_: Optional[str] = Field(None, alias="schema")  # default: event_log.schema
     streaming_table: str = "all_pipelines_event_log"  # user-created Delta table
     checkpoint_path: str = ""  # streaming checkpoint base path (required when enabled)
+    job_config_path: Optional[str] = None  # relative path to monitoring job config YAML (required when enabled)
     max_concurrent_streams: int = 10  # ThreadPoolExecutor max_workers
     materialized_views: Optional[List[MonitoringMaterializedViewConfig]] = None
     enable_job_monitoring: bool = False

--- a/src/lhp/schemas/project.schema.json
+++ b/src/lhp/schemas/project.schema.json
@@ -178,6 +178,11 @@
                     "type": "string",
                     "description": "Base path for streaming checkpoints. Each pipeline gets a subdirectory: {checkpoint_path}/{pipeline_name}/"
                 },
+                "job_config_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Relative path (from project root) to the dedicated monitoring job config YAML. Required when monitoring.enabled is true (enforced at validation time)."
+                },
                 "max_concurrent_streams": {
                     "type": "integer",
                     "default": 10,

--- a/src/lhp/templates/init/config/monitoring_job_config_env.yaml.tmpl
+++ b/src/lhp/templates/init/config/monitoring_job_config_env.yaml.tmpl
@@ -1,0 +1,99 @@
+# ==============================================================================
+# LakehousePlumber Monitoring Job Configuration
+# ==============================================================================
+#
+# This file describes the Databricks Workflow Job that LHP generates alongside
+# the event-log monitoring pipeline. It is a **flat, single-document YAML** —
+# no `project_defaults:` wrapper and no `job_name:` key.
+#
+# The monitoring job chains:
+#   notebook_task (union event logs)  →  pipeline_task (monitoring MVs)
+#
+# This file is REQUIRED when monitoring is enabled in lhp.yaml. Point to it
+# via `monitoring.job_config_path` (relative to project root).
+#
+# Tokens like ${bundle_target} are resolved using the active environment's
+# substitutions/<env>.yaml exactly like the rest of the generated code.
+#
+# Usage:
+#   1. Copy or rename this file to remove the .tmpl extension.
+#   2. Reference it from lhp.yaml:
+#        monitoring:
+#          enabled: true
+#          checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#          job_config_path: "config/monitoring_job_config.yaml"
+#
+# Documentation: See docs/monitoring.rst for full details.
+# ==============================================================================
+
+# Maximum number of concurrent runs of the monitoring job
+# Keep this at 1 for monitoring to avoid checkpoint contention.
+max_concurrent_runs: 1
+
+# Performance target for job execution.
+# Options:
+#   - STANDARD: cost-effective, slower cluster startup
+#   - PERFORMANCE_OPTIMIZED: faster startup, higher cost
+performance_target: STANDARD
+
+# Queue settings — let runs queue instead of being dropped.
+queue:
+  enabled: true
+
+# Tags for cost tracking and organization.
+tags:
+  managed_by: lakehouse_plumber
+  environment: ${bundle_target}
+  # project: my_project
+  # team: data-platform
+
+# Optional: job-level timeout (seconds). Uncomment to enable.
+# timeout_seconds: 3600
+
+# Optional: cluster overrides for the union notebook task.
+# Uncomment and tune based on the number of event-log streams you union.
+# notebook_cluster:
+#   spark_version: "15.4.x-scala2.12"
+#   node_type_id: "i3.xlarge"
+#   num_workers: 2
+
+# Optional: email notifications.
+# email_notifications:
+#   on_failure:
+#     - data-platform-oncall@company.com
+
+# Optional: webhook notifications.
+# webhook_notifications:
+#   on_failure:
+#     - id: pagerduty_alert
+
+# Optional: schedule. Uncomment to run on a cron.
+# schedule:
+#   quartz_cron_expression: "0 0 * * * ?"     # hourly
+#   timezone_id: "America/New_York"
+#   pause_status: "UNPAUSED"
+
+# Optional: permissions.
+# permissions:
+#   - level: CAN_VIEW
+#     user_name: user@company.com
+#   - level: CAN_MANAGE_RUN
+#     group_name: data-platform
+
+# ==============================================================================
+# Notes
+# ==============================================================================
+#
+# MERGE BEHAVIOR:
+#   The values above are deep-merged over LHP's DEFAULT_JOB_CONFIG
+#   (max_concurrent_runs=1, performance_target=STANDARD, queue.enabled=true).
+#   Nested dicts (tags, queue) are deep-merged; lists are replaced wholesale.
+#
+# DO NOT:
+#   - Wrap the config in a `project_defaults:` key (that format is only for
+#     the generic multi-job orchestration config used by `lhp deps`).
+#   - Add a `job_name:` key. The monitoring job name is auto-derived from
+#     `monitoring.pipeline_name` (or the default) as `<pipeline_name>_job`.
+#
+# For detailed documentation, see: docs/monitoring.rst
+# ==============================================================================

--- a/src/lhp/templates/init/lhp.yaml.j2
+++ b/src/lhp/templates/init/lhp.yaml.j2
@@ -78,9 +78,11 @@ operational_metadata:
 ## Requires event_log to be enabled above.
 ## See docs/monitoring.rst for full configuration reference.
 ##
-## Minimal setup (uses sensible defaults — checkpoint_path is required):
+## Minimal setup (uses sensible defaults — checkpoint_path AND
+## job_config_path are required when monitoring is enabled):
 # monitoring:
 #   checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#   job_config_path: "config/monitoring_job_config.yaml"
 ##
 ## Custom configuration example:
 # monitoring:
@@ -89,6 +91,7 @@ operational_metadata:
 #   schema: "_monitoring"                  # Default: inherits from event_log.schema
 #   streaming_table: "unified_event_log"   # Default: all_pipelines_event_log
 #   checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"  # required
+#   job_config_path: "config/monitoring_job_config.yaml"                 # required
 #   max_concurrent_streams: 10             # Default: 10 (ThreadPoolExecutor size)
 #   materialized_views:                    # Default: one events_summary MV
 #     - name: "error_events"

--- a/src/lhp/templates/monitoring/union_event_logs.py.j2
+++ b/src/lhp/templates/monitoring/union_event_logs.py.j2
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -19,6 +20,46 @@ SOURCES = [
 {% for pipeline_name, table_ref in sources %}
     ({{ pipeline_name | tojson }}, {{ table_ref | tojson }}),
 {% endfor %}]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/config/monitoring_job_config.yaml
+++ b/tests/e2e/fixtures/testing_project/config/monitoring_job_config.yaml
@@ -1,0 +1,9 @@
+# Monitoring job config used by E2E monitoring-variant tests.
+# Flat single-document YAML — no project_defaults wrapper, no job_name key.
+max_concurrent_runs: 1
+performance_target: STANDARD
+queue:
+  enabled: true
+tags:
+  managed_by: lakehouse_plumber
+  environment: ${bundle_target}

--- a/tests/e2e/fixtures/testing_project/config/monitoring_job_config_custom.yaml
+++ b/tests/e2e/fixtures/testing_project/config/monitoring_job_config_custom.yaml
@@ -1,0 +1,20 @@
+# Rich monitoring-job config — used by the monitoring_custom_job_config E2E
+# variant to verify every supported key flows from this file into the generated
+# resources/<pipeline>.job.yml.
+max_concurrent_runs: 2
+performance_target: PERFORMANCE_OPTIMIZED
+queue:
+  enabled: true
+timeout_seconds: 3600
+tags:
+  managed_by: lakehouse_plumber
+  environment: ${bundle_target}
+  purpose: event_log_monitoring
+  team: data-platform
+email_notifications:
+  on_failure:
+    - monitoring-alerts@example.com
+schedule:
+  quartz_cron_expression: "0 0 * * * ?"
+  timezone_id: UTC
+  pause_status: UNPAUSED

--- a/tests/e2e/fixtures/testing_project/lhp.yaml
+++ b/tests/e2e/fixtures/testing_project/lhp.yaml
@@ -67,26 +67,31 @@ operational_metadata:
 ## [monitoring_default]
 #monitoring:
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 
 ## [monitoring_custom_pipeline_name]
 #monitoring:
 #  pipeline_name: "my_custom_monitor"
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 
 ## [monitoring_catalog_schema_override]
 #monitoring:
 #  catalog: "analytics_cat"
 #  schema: "_analytics"
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 
 ## [monitoring_custom_streaming_table]
 #monitoring:
 #  streaming_table: "unified_event_log"
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 
 ## [monitoring_custom_mvs]
 #monitoring:
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 #  materialized_views:
 #    - name: "error_events"
 #      sql: "SELECT * FROM all_pipelines_event_log WHERE event_type = 'error'"
@@ -96,11 +101,13 @@ operational_metadata:
 ## [monitoring_no_mvs]
 #monitoring:
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 #  materialized_views: []
 
 ## [monitoring_mv_sql_path]
 #monitoring:
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 #  materialized_views:
 #    - name: "custom_analysis"
 #      sql_path: "sql/monitoring_custom_analysis.sql"
@@ -108,7 +115,15 @@ operational_metadata:
 ## [monitoring_enable_job_monitoring]
 #monitoring:
 #  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config.yaml"
 #  enable_job_monitoring: true
+
+## [monitoring_custom_job_config]
+## Variant that exercises a richer monitoring_job_config.yaml (tags,
+## performance target, timeout, notifications) via the dedicated path.
+#monitoring:
+#  checkpoint_path: "/Volumes/${catalog}/_meta/checkpoints/event_logs"
+#  job_config_path: "config/monitoring_job_config_custom.yaml"
 
 ## Test result reporting to external systems
 test_reporting:

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/catalog_schema_override/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/catalog_schema_override/acme_edw_event_log_monitoring.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/catalog_schema_override/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/catalog_schema_override/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_mvs/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_mvs/acme_edw_event_log_monitoring.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_mvs/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_mvs/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_pipeline_name/my_custom_monitor.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_pipeline_name/my_custom_monitor.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_pipeline_name/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_pipeline_name/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_streaming_table/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_streaming_table/acme_edw_event_log_monitoring.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_streaming_table/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/custom_streaming_table/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/default/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/default/acme_edw_event_log_monitoring.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/default/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/default/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/enable_job_monitoring/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/enable_job_monitoring/acme_edw_event_log_monitoring.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/enable_job_monitoring/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/enable_job_monitoring/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/mv_sql_path/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/mv_sql_path/acme_edw_event_log_monitoring.job.yml
@@ -19,3 +19,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/mv_sql_path/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/mv_sql_path/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/no_mvs/acme_edw_event_log_monitoring.job.yml
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/no_mvs/acme_edw_event_log_monitoring.job.yml
@@ -13,3 +13,6 @@ resources:
       queue:
         enabled: true
       performance_target: STANDARD
+      tags:
+        managed_by: "lakehouse_plumber"
+        environment: "${bundle_target}"

--- a/tests/e2e/fixtures/testing_project/monitoring_baseline/no_mvs/union_event_logs.py
+++ b/tests/e2e/fixtures/testing_project/monitoring_baseline/no_mvs/union_event_logs.py
@@ -7,6 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pyspark.sql import functions as F
+from pyspark.sql.utils import AnalysisException
 
 # ---------------------------------------------------------------------------
 # Configuration (injected at generation time)
@@ -26,6 +27,46 @@ SOURCES = [
     ("namespace_validation", "acme_edw_dev._meta.namespace_validation_event_log"),
     ("sample_python_func_pipeline", "acme_edw_dev._meta.sample_python_func_pipeline_event_log"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Prologue — pre-create the target table to avoid a cold-run CREATE race
+# ---------------------------------------------------------------------------
+# The parallel streaming queries below all call .toTable(TARGET_TABLE). On a
+# cold run (target table does not yet exist), every worker races to CREATE
+# the table; one wins, the rest fail with TABLE_OR_VIEW_ALREADY_EXISTS. We
+# pre-create the table here using the schema of any readable source event
+# log. Event-log schemas are uniform across DLT pipelines, and each stream
+# uses mergeSchema=true to absorb any runtime-specific columns.
+def _ensure_target_exists() -> None:
+    """Pre-create TARGET_TABLE so parallel streams do not race on first run.
+
+    Idempotent: no-op if the table already exists. Tries each source in
+    SOURCES order until one event log is readable; raises RuntimeError only
+    if no source is readable.
+    """
+    if spark.catalog.tableExists(TARGET_TABLE):  # noqa: F821
+        return
+    last_error: Exception | None = None
+    for sample_name, sample_ref in SOURCES:
+        try:
+            empty = (
+                spark.read.format("delta").table(sample_ref).limit(0)  # noqa: F821
+                .withColumn("_source_pipeline", F.lit(sample_name))
+            )
+            empty.write.format("delta").saveAsTable(TARGET_TABLE)
+            return
+        except AnalysisException as exc:
+            last_error = exc
+            continue
+    raise RuntimeError(
+        f"Unable to create target table {TARGET_TABLE}: no source event log "
+        f"readable among {[ref for _, ref in SOURCES]}. Last error: {last_error}"
+    )
+
+
+if SOURCES:
+    _ensure_target_exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_pipeline_config_e2e.py
+++ b/tests/e2e/test_pipeline_config_e2e.py
@@ -1181,40 +1181,58 @@ class TestMonitoringPipelineE2E:
 
     _CP = "/Volumes/${catalog}/_meta/checkpoints/event_logs"
 
+    # job_config_path is required when monitoring is enabled — every variant
+    # points at ``config/monitoring_job_config.yaml`` in the fixture project.
+    # The ``monitoring_custom_job_config`` variant uses a richer file to
+    # exercise deep-merge, schedule, notifications, and tags.
+    _JC = "config/monitoring_job_config.yaml"
+    _JC_CUSTOM = "config/monitoring_job_config_custom.yaml"
+
     MONITORING_VARIANTS = {
         "monitoring_default": (
-            "#monitoring:\n" '#  checkpoint_path: "' + _CP + '"',
-            "monitoring:\n" '  checkpoint_path: "' + _CP + '"',
+            "#monitoring:\n"
+            '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"',
+            "monitoring:\n"
+            '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"',
         ),
         "monitoring_custom_pipeline_name": (
             "#monitoring:\n"
             '#  pipeline_name: "my_custom_monitor"\n'
-            '#  checkpoint_path: "' + _CP + '"',
+            '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"',
             "monitoring:\n"
             '  pipeline_name: "my_custom_monitor"\n'
-            '  checkpoint_path: "' + _CP + '"',
+            '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"',
         ),
         "monitoring_catalog_schema_override": (
             "#monitoring:\n"
             '#  catalog: "analytics_cat"\n'
             '#  schema: "_analytics"\n'
-            '#  checkpoint_path: "' + _CP + '"',
+            '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"',
             "monitoring:\n"
             '  catalog: "analytics_cat"\n'
             '  schema: "_analytics"\n'
-            '  checkpoint_path: "' + _CP + '"',
+            '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"',
         ),
         "monitoring_custom_streaming_table": (
             "#monitoring:\n"
             '#  streaming_table: "unified_event_log"\n'
-            '#  checkpoint_path: "' + _CP + '"',
+            '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"',
             "monitoring:\n"
             '  streaming_table: "unified_event_log"\n'
-            '  checkpoint_path: "' + _CP + '"',
+            '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"',
         ),
         "monitoring_custom_mvs": (
             "#monitoring:\n"
             '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"\n'
             "#  materialized_views:\n"
             '#    - name: "error_events"\n'
             '#      sql: "SELECT * FROM all_pipelines_event_log'
@@ -1225,6 +1243,7 @@ class TestMonitoringPipelineE2E:
             ' GROUP BY _source_pipeline"',
             "monitoring:\n"
             '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"\n'
             "  materialized_views:\n"
             '    - name: "error_events"\n'
             '      sql: "SELECT * FROM all_pipelines_event_log'
@@ -1237,19 +1256,23 @@ class TestMonitoringPipelineE2E:
         "monitoring_no_mvs": (
             "#monitoring:\n"
             '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"\n'
             "#  materialized_views: []",
             "monitoring:\n"
             '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"\n'
             "  materialized_views: []",
         ),
         "monitoring_mv_sql_path": (
             "#monitoring:\n"
             '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"\n'
             "#  materialized_views:\n"
             '#    - name: "custom_analysis"\n'
             '#      sql_path: "sql/monitoring_custom_analysis.sql"',
             "monitoring:\n"
             '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"\n'
             "  materialized_views:\n"
             '    - name: "custom_analysis"\n'
             '      sql_path: "sql/monitoring_custom_analysis.sql"',
@@ -1257,10 +1280,20 @@ class TestMonitoringPipelineE2E:
         "monitoring_enable_job_monitoring": (
             "#monitoring:\n"
             '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC + '"\n'
             "#  enable_job_monitoring: true",
             "monitoring:\n"
             '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC + '"\n'
             "  enable_job_monitoring: true",
+        ),
+        "monitoring_custom_job_config": (
+            "#monitoring:\n"
+            '#  checkpoint_path: "' + _CP + '"\n'
+            '#  job_config_path: "' + _JC_CUSTOM + '"',
+            "monitoring:\n"
+            '  checkpoint_path: "' + _CP + '"\n'
+            '  job_config_path: "' + _JC_CUSTOM + '"',
         ),
     }
 
@@ -1708,6 +1741,82 @@ class TestMonitoringPipelineE2E:
         assert (
             loader_content == expected
         ), "Generated jobs_stats_loader.py does not match package resource"
+
+    # ------------------------------------------------------------------
+    # Test 10b: dedicated monitoring job_config_path with rich overrides
+    # ------------------------------------------------------------------
+
+    def test_monitoring_custom_job_config(self):
+        """A rich monitoring_job_config.yaml is loaded, token-substituted, and
+        deep-merged over defaults; all overrides flow into the generated job
+        YAML. Regression guard for the dedicated-file contract that replaced
+        the legacy ``__eventlog_monitoring`` alias path."""
+        self._enable_event_log()
+        self._enable_monitoring_variant("monitoring_custom_job_config")
+
+        exit_code, output = self._run_generate()
+        assert exit_code == 0, f"Generation failed: {output}"
+
+        # Hash-check monitoring notebook + pipeline code match the default
+        # variant (this variant only changes the *job* config, not the
+        # notebook or MVs).
+        self._assert_monitoring_py_baseline("default")
+        self._assert_monitoring_notebook_baseline("default")
+
+        # Job YAML must reflect the rich overrides + substituted tokens.
+        job_yml = (
+            self.resources_root / "acme_edw_event_log_monitoring.job.yml"
+        )
+        assert job_yml.exists(), f"Monitoring job YAML not generated: {job_yml}"
+        parsed = yaml.safe_load(job_yml.read_text())
+        job = parsed["resources"]["jobs"]["acme_edw_event_log_monitoring_job"]
+
+        # Scalar overrides
+        assert job["max_concurrent_runs"] == 2
+        assert job["performance_target"] == "PERFORMANCE_OPTIMIZED"
+        assert job["timeout_seconds"] == 3600
+        assert job["queue"]["enabled"] is True
+
+        # Tags deep-merged + token substituted. ${bundle_target} is not
+        # defined in substitutions/dev.yaml so it is preserved verbatim for
+        # Databricks Asset Bundles to resolve at deploy time.
+        assert job["tags"]["managed_by"] == "lakehouse_plumber"
+        assert job["tags"]["environment"] == "${bundle_target}"
+        assert job["tags"]["purpose"] == "event_log_monitoring"
+        assert job["tags"]["team"] == "data-platform"
+
+        # Email notifications flow through
+        assert job["email_notifications"]["on_failure"] == [
+            "monitoring-alerts@example.com"
+        ]
+
+        # Schedule flows through
+        assert job["schedule"]["quartz_cron_expression"] == "0 0 * * * ?"
+        assert job["schedule"]["timezone_id"] == "UTC"
+        assert job["schedule"]["pause_status"] == "UNPAUSED"
+
+    # ------------------------------------------------------------------
+    # Test 10c: missing job_config_path file surfaces a clear error
+    # ------------------------------------------------------------------
+
+    def test_monitoring_job_config_file_missing_fails(self):
+        """If monitoring.job_config_path points to a non-existent file, the
+        CLI must fail with a clear LHP-CFG-008 error at validation time —
+        before any generation work starts."""
+        self._enable_event_log()
+        # Hand-roll a monitoring block that references a file we do NOT create
+        self.lhp_yaml.write_text(
+            self.lhp_yaml.read_text()
+            + "\nmonitoring:\n"
+            '  checkpoint_path: "/Volumes/cat/_meta/checkpoints/event_logs"\n'
+            '  job_config_path: "config/does_not_exist.yaml"\n'
+        )
+
+        exit_code, output = self._run_generate()
+        assert exit_code != 0, "Expected generation to fail for missing job config"
+        assert (
+            "job_config" in output or "job_config_path" in output
+        ), f"Error message should mention job_config: {output}"
 
     # ------------------------------------------------------------------
     # Test 11: monitoring pipeline picks up pipeline_config.yaml settings

--- a/tests/unit/test_monitoring_config_loader.py
+++ b/tests/unit/test_monitoring_config_loader.py
@@ -9,11 +9,28 @@ from lhp.models.config import EventLogConfig, MonitoringConfig
 from lhp.utils.error_formatter import LHPError
 
 
+# Path (relative to project root / tmp_path) used across tests as the monitoring
+# job config location. The `loader` fixture creates this file so validation passes.
+JOB_CFG_REL = "config/monitoring_job_config.yaml"
+
+
 @pytest.fixture
 def loader(tmp_path):
-    """Create a ProjectConfigLoader with a minimal lhp.yaml."""
+    """Create a ProjectConfigLoader with a minimal lhp.yaml and a valid
+    monitoring job config file on disk so the required-file validation passes.
+    """
     lhp_yaml = tmp_path / "lhp.yaml"
     lhp_yaml.write_text("name: test_project\n")
+    job_cfg_file = tmp_path / JOB_CFG_REL
+    job_cfg_file.parent.mkdir(parents=True, exist_ok=True)
+    job_cfg_file.write_text(
+        "max_concurrent_runs: 1\n"
+        "performance_target: STANDARD\n"
+        "queue:\n"
+        "  enabled: true\n"
+        "tags:\n"
+        "  managed_by: lakehouse_plumber\n"
+    )
     return ProjectConfigLoader(tmp_path)
 
 
@@ -25,21 +42,20 @@ class TestParseMonitoringConfig:
         """monitoring: {} should produce all-default MonitoringConfig."""
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
         config = loader._parse_monitoring_config(
-            {"checkpoint_path": "/mnt/cp"}, event_log
+            {"checkpoint_path": "/mnt/cp", "job_config_path": JOB_CFG_REL}, event_log
         )
         assert isinstance(config, MonitoringConfig)
         assert config.enabled is True
         assert config.pipeline_name is None
         assert config.streaming_table == "all_pipelines_event_log"
         assert config.checkpoint_path == "/mnt/cp"
+        assert config.job_config_path == JOB_CFG_REL
 
     def test_none_treated_as_empty_dict(self, loader):
         """monitoring: (null) should also produce defaults."""
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
-        # None input with no checkpoint_path would fail validation,
-        # but _parse_monitoring_config returns before validation on disabled
         config = loader._parse_monitoring_config(
-            {"checkpoint_path": "/mnt/cp"}, event_log
+            {"checkpoint_path": "/mnt/cp", "job_config_path": JOB_CFG_REL}, event_log
         )
         assert config.enabled is True
 
@@ -48,6 +64,7 @@ class TestParseMonitoringConfig:
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
         config = loader._parse_monitoring_config({"enabled": False}, event_log)
         assert config.enabled is False
+        assert config.job_config_path is None
 
     def test_custom_fields(self, loader):
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
@@ -58,6 +75,7 @@ class TestParseMonitoringConfig:
                 "schema": "_analytics",
                 "streaming_table": "unified_events",
                 "checkpoint_path": "/mnt/cp",
+                "job_config_path": JOB_CFG_REL,
             },
             event_log,
         )
@@ -65,12 +83,14 @@ class TestParseMonitoringConfig:
         assert config.catalog == "override_cat"
         assert config.schema_ == "_analytics"
         assert config.streaming_table == "unified_events"
+        assert config.job_config_path == JOB_CFG_REL
 
     def test_with_materialized_views(self, loader):
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
         config = loader._parse_monitoring_config(
             {
                 "checkpoint_path": "/mnt/cp",
+                "job_config_path": JOB_CFG_REL,
                 "materialized_views": [
                     {"name": "summary", "sql": "SELECT 1"},
                     {"name": "errors", "sql_path": "queries/errors.sql"},
@@ -85,7 +105,12 @@ class TestParseMonitoringConfig:
     def test_empty_materialized_views_list(self, loader):
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
         config = loader._parse_monitoring_config(
-            {"checkpoint_path": "/mnt/cp", "materialized_views": []}, event_log
+            {
+                "checkpoint_path": "/mnt/cp",
+                "job_config_path": JOB_CFG_REL,
+                "materialized_views": [],
+            },
+            event_log,
         )
         assert config.materialized_views == []
 
@@ -98,6 +123,7 @@ class TestParseMonitoringConfig:
                 "catalog": "${catalog}",
                 "schema": "${schema}",
                 "checkpoint_path": "/mnt/cp",
+                "job_config_path": JOB_CFG_REL,
             },
             event_log,
         )
@@ -129,9 +155,17 @@ class TestValidateMonitoringConfig:
     """Tests for _validate_monitoring_config method."""
 
     def test_disabled_skips_validation(self, loader):
-        """Disabled monitoring should not raise even without event_log."""
+        """Disabled monitoring should not raise even without event_log or job_config_path."""
         config = MonitoringConfig(enabled=False)
         loader._validate_monitoring_config(config, None)
+
+    def test_disabled_without_job_config_path_passes(self, loader):
+        """enabled=False + missing job_config_path should NOT raise (required only when enabled)."""
+        config = MonitoringConfig(
+            enabled=False, checkpoint_path="/mnt/cp", job_config_path=None
+        )
+        event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
+        loader._validate_monitoring_config(config, event_log)
 
     def test_enabled_without_event_log_raises(self, loader):
         config = MonitoringConfig(enabled=True)
@@ -145,15 +179,66 @@ class TestValidateMonitoringConfig:
             loader._validate_monitoring_config(config, event_log)
 
     def test_enabled_with_event_log_passes(self, loader):
-        config = MonitoringConfig(enabled=True, checkpoint_path="/mnt/cp")
+        config = MonitoringConfig(
+            enabled=True, checkpoint_path="/mnt/cp", job_config_path=JOB_CFG_REL
+        )
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
         loader._validate_monitoring_config(config, event_log)
 
     def test_missing_checkpoint_path_raises(self, loader):
-        config = MonitoringConfig(enabled=True)
+        config = MonitoringConfig(enabled=True, job_config_path=JOB_CFG_REL)
         event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
         with pytest.raises(LHPError, match="checkpoint_path is required"):
             loader._validate_monitoring_config(config, event_log)
+
+    def test_missing_job_config_path_raises(self, loader):
+        """enabled=True + checkpoint_path set but job_config_path missing → error."""
+        config = MonitoringConfig(
+            enabled=True, checkpoint_path="/mnt/cp", job_config_path=None
+        )
+        event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
+        with pytest.raises(LHPError, match="job_config_path is required"):
+            loader._validate_monitoring_config(config, event_log)
+
+    def test_empty_job_config_path_raises(self, loader):
+        """enabled=True + empty string job_config_path → error (treated same as missing)."""
+        config = MonitoringConfig(
+            enabled=True, checkpoint_path="/mnt/cp", job_config_path=""
+        )
+        event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
+        with pytest.raises(LHPError, match="job_config_path is required"):
+            loader._validate_monitoring_config(config, event_log)
+
+    def test_job_config_path_file_not_found_raises(self, loader):
+        """enabled=True + job_config_path points to non-existent file → error."""
+        config = MonitoringConfig(
+            enabled=True,
+            checkpoint_path="/mnt/cp",
+            job_config_path="config/does_not_exist.yaml",
+        )
+        event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
+        with pytest.raises(LHPError, match="job_config file not found"):
+            loader._validate_monitoring_config(config, event_log)
+
+    def test_job_config_path_resolved_relative_to_project_root(self, loader):
+        """Existing file at project_root / job_config_path should pass."""
+        config = MonitoringConfig(
+            enabled=True,
+            checkpoint_path="/mnt/cp",
+            job_config_path=JOB_CFG_REL,  # created by fixture under project_root
+        )
+        event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
+        loader._validate_monitoring_config(config, event_log)
+
+    def test_tokenized_job_config_path_defers_existence_check(self, loader):
+        """Paths containing ${...} tokens are validated later (once env is known)."""
+        config = MonitoringConfig(
+            enabled=True,
+            checkpoint_path="/mnt/cp",
+            job_config_path="config/monitoring_job_config_${env}.yaml",
+        )
+        event_log = EventLogConfig(enabled=True, catalog="cat", schema="_meta")
+        loader._validate_monitoring_config(config, event_log)
 
     def test_duplicate_mv_names_raises(self, loader):
         from lhp.models.config import MonitoringMaterializedViewConfig
@@ -161,6 +246,7 @@ class TestValidateMonitoringConfig:
         config = MonitoringConfig(
             enabled=True,
             checkpoint_path="/mnt/cp",
+            job_config_path=JOB_CFG_REL,
             materialized_views=[
                 MonitoringMaterializedViewConfig(name="summary", sql="SELECT 1"),
                 MonitoringMaterializedViewConfig(name="summary", sql="SELECT 2"),
@@ -176,6 +262,7 @@ class TestValidateMonitoringConfig:
         config = MonitoringConfig(
             enabled=True,
             checkpoint_path="/mnt/cp",
+            job_config_path=JOB_CFG_REL,
             materialized_views=[
                 MonitoringMaterializedViewConfig(
                     name="summary", sql="SELECT 1", sql_path="q.sql"
@@ -192,6 +279,7 @@ class TestValidateMonitoringConfig:
         config = MonitoringConfig(
             enabled=True,
             checkpoint_path="/mnt/cp",
+            job_config_path=JOB_CFG_REL,
             materialized_views=[
                 MonitoringMaterializedViewConfig(name="", sql="SELECT 1"),
             ],
@@ -206,6 +294,7 @@ class TestValidateMonitoringConfig:
         config = MonitoringConfig(
             enabled=True,
             checkpoint_path="/mnt/cp",
+            job_config_path=JOB_CFG_REL,
             materialized_views=[
                 MonitoringMaterializedViewConfig(name="summary", sql="SELECT 1"),
                 MonitoringMaterializedViewConfig(name="errors", sql="SELECT 2"),
@@ -228,11 +317,15 @@ class TestParseProjectConfigWithMonitoring:
             {
                 "name": "test_project",
                 "event_log": {"catalog": "cat", "schema": "_meta"},
-                "monitoring": {"checkpoint_path": "/mnt/cp"},
+                "monitoring": {
+                    "checkpoint_path": "/mnt/cp",
+                    "job_config_path": JOB_CFG_REL,
+                },
             }
         )
         assert config.monitoring is not None
         assert config.monitoring.enabled is True
+        assert config.monitoring.job_config_path == JOB_CFG_REL
 
     def test_monitoring_disabled(self, loader):
         config = loader._parse_project_config(
@@ -254,6 +347,21 @@ class TestParseProjectConfigWithMonitoring:
                 }
             )
 
+    def test_monitoring_enabled_without_job_config_path_raises(self, loader):
+        """Parsing a full project config with monitoring enabled but no
+        job_config_path should surface the new validation error."""
+        with pytest.raises(LHPError, match="job_config_path is required"):
+            loader._parse_project_config(
+                {
+                    "name": "test_project",
+                    "event_log": {"catalog": "cat", "schema": "_meta"},
+                    "monitoring": {
+                        "enabled": True,
+                        "checkpoint_path": "/mnt/cp",
+                    },
+                }
+            )
+
     def test_monitoring_with_full_config(self, loader):
         config = loader._parse_project_config(
             {
@@ -264,6 +372,7 @@ class TestParseProjectConfigWithMonitoring:
                     "catalog": "override",
                     "streaming_table": "unified",
                     "checkpoint_path": "/mnt/cp",
+                    "job_config_path": JOB_CFG_REL,
                     "materialized_views": [
                         {"name": "summary", "sql": "SELECT 1"},
                     ],
@@ -273,4 +382,5 @@ class TestParseProjectConfigWithMonitoring:
         assert config.monitoring.pipeline_name == "my_monitor"
         assert config.monitoring.catalog == "override"
         assert config.monitoring.streaming_table == "unified"
+        assert config.monitoring.job_config_path == JOB_CFG_REL
         assert len(config.monitoring.materialized_views) == 1

--- a/tests/unit/test_monitoring_job_generator.py
+++ b/tests/unit/test_monitoring_job_generator.py
@@ -1,0 +1,154 @@
+"""Unit tests for the simplified JobGenerator monitoring-job API.
+
+Covers:
+  * ``JobGenerator.resolve_monitoring_job_config`` — deep-merges raw dict over
+    ``DEFAULT_JOB_CONFIG`` without touching callers.
+  * ``JobGenerator.generate_monitoring_job`` — renders the monitoring-job Jinja
+    template against the caller-supplied ``job_config`` dict (no alias lookup,
+    no monitoring_job_name member state).
+"""
+
+import pytest
+import yaml
+
+from lhp.core.services.job_generator import JobGenerator
+
+
+@pytest.mark.unit
+class TestResolveMonitoringJobConfig:
+    """Tests for JobGenerator.resolve_monitoring_job_config classmethod."""
+
+    def test_empty_input_returns_defaults(self):
+        resolved = JobGenerator.resolve_monitoring_job_config({})
+        assert resolved["max_concurrent_runs"] == 1
+        assert resolved["performance_target"] == "STANDARD"
+        assert resolved["queue"] == {"enabled": True}
+
+    def test_none_input_returns_defaults(self):
+        """None is tolerated (empty file case)."""
+        resolved = JobGenerator.resolve_monitoring_job_config(None)
+        assert resolved["max_concurrent_runs"] == 1
+
+    def test_scalar_override(self):
+        resolved = JobGenerator.resolve_monitoring_job_config(
+            {"max_concurrent_runs": 4, "performance_target": "PERFORMANCE_OPTIMIZED"}
+        )
+        assert resolved["max_concurrent_runs"] == 4
+        assert resolved["performance_target"] == "PERFORMANCE_OPTIMIZED"
+
+    def test_nested_deep_merge_tags(self):
+        """Nested dicts (tags, queue) merge recursively."""
+        resolved = JobGenerator.resolve_monitoring_job_config(
+            {"tags": {"team": "data-platform"}, "queue": {"enabled": False}}
+        )
+        assert resolved["queue"] == {"enabled": False}
+        assert resolved["tags"] == {"team": "data-platform"}
+
+    def test_new_keys_preserved(self):
+        resolved = JobGenerator.resolve_monitoring_job_config(
+            {"timeout_seconds": 3600, "schedule": {"quartz_cron_expression": "0 * * * * ?"}}
+        )
+        assert resolved["timeout_seconds"] == 3600
+        assert resolved["schedule"]["quartz_cron_expression"] == "0 * * * * ?"
+
+    def test_does_not_mutate_default(self):
+        JobGenerator.resolve_monitoring_job_config({"max_concurrent_runs": 9})
+        # DEFAULT_JOB_CONFIG must still be pristine
+        assert JobGenerator.DEFAULT_JOB_CONFIG["max_concurrent_runs"] == 1
+
+
+@pytest.mark.unit
+class TestGenerateMonitoringJobSimplified:
+    """Tests for the simplified ``generate_monitoring_job`` signature."""
+
+    def test_renders_with_minimal_job_config(self):
+        """New signature: ``job_config`` passed explicitly, no alias lookup."""
+        gen = JobGenerator()
+        job_cfg = JobGenerator.resolve_monitoring_job_config(
+            {"tags": {"purpose": "monitor"}}
+        )
+        rendered = gen.generate_monitoring_job(
+            pipeline_name="my_monitor",
+            notebook_path="/Workspace/x/union_event_logs",
+            job_name="my_monitor_job",
+            job_config=job_cfg,
+            has_pipeline=True,
+        )
+        assert "my_monitor_job" in rendered
+        assert "union_event_logs" in rendered
+        assert "purpose" in rendered  # tag flowed through
+        # Parses as valid YAML
+        parsed = yaml.safe_load(rendered)
+        assert parsed["resources"]["jobs"]["my_monitor_job"]["name"] == "my_monitor_job"
+        assert (
+            parsed["resources"]["jobs"]["my_monitor_job"]["max_concurrent_runs"] == 1
+        )
+
+    def test_has_pipeline_false_emits_notebook_only_job(self):
+        gen = JobGenerator()
+        job_cfg = JobGenerator.resolve_monitoring_job_config({})
+        rendered = gen.generate_monitoring_job(
+            pipeline_name="my_monitor",
+            notebook_path="/Workspace/x/union_event_logs",
+            job_name="my_monitor_job",
+            job_config=job_cfg,
+            has_pipeline=False,
+        )
+        parsed = yaml.safe_load(rendered)
+        tasks = parsed["resources"]["jobs"]["my_monitor_job"]["tasks"]
+        assert len(tasks) == 1
+        assert tasks[0]["task_key"] == "union_event_logs"
+
+    def test_has_pipeline_true_emits_pipeline_task(self):
+        gen = JobGenerator()
+        job_cfg = JobGenerator.resolve_monitoring_job_config({})
+        rendered = gen.generate_monitoring_job(
+            pipeline_name="my_monitor",
+            notebook_path="/Workspace/x/union_event_logs",
+            job_name="my_monitor_job",
+            job_config=job_cfg,
+            has_pipeline=True,
+        )
+        parsed = yaml.safe_load(rendered)
+        tasks = parsed["resources"]["jobs"]["my_monitor_job"]["tasks"]
+        assert len(tasks) == 2
+        assert {t["task_key"] for t in tasks} == {
+            "union_event_logs",
+            "my_monitor_pipeline",
+        }
+
+    def test_caller_controls_everything_no_alias_lookup(self):
+        """Regression guard: JobGenerator must no longer pull monitoring config
+        out of templates/bundle/job_config.yaml via the __eventlog_monitoring
+        alias. The job_config argument is the sole source of truth."""
+        gen = JobGenerator()
+        # Intentionally pass an override for performance_target. The rendered
+        # output must reflect the caller's value — not DEFAULT or some loaded
+        # file — confirming the caller-owned config path.
+        job_cfg = JobGenerator.resolve_monitoring_job_config(
+            {"performance_target": "PERFORMANCE_OPTIMIZED"}
+        )
+        rendered = gen.generate_monitoring_job(
+            pipeline_name="m",
+            notebook_path="/p",
+            job_name="m_job",
+            job_config=job_cfg,
+            has_pipeline=False,
+        )
+        assert "performance_target: PERFORMANCE_OPTIMIZED" in rendered
+
+
+@pytest.mark.unit
+class TestJobGeneratorNoMonitoringAliasAttrs:
+    """Regression guards: the monitoring-alias surface is gone from JobGenerator."""
+
+    def test_no_monitoring_job_name_param(self):
+        """Constructor no longer accepts ``monitoring_job_name``."""
+        with pytest.raises(TypeError):
+            JobGenerator(monitoring_job_name="some_job")  # type: ignore[call-arg]
+
+    def test_no_monitoring_job_alias_constant(self):
+        assert not hasattr(JobGenerator, "MONITORING_JOB_ALIAS")
+
+    def test_no_resolve_monitoring_alias_method(self):
+        assert not hasattr(JobGenerator, "_resolve_monitoring_alias")

--- a/tests/unit/test_monitoring_pipeline_builder.py
+++ b/tests/unit/test_monitoring_pipeline_builder.py
@@ -440,6 +440,35 @@ class TestTemplateContext:
         assert sources[0][1] == "my_catalog._meta.bronze_event_log"
 
 
+class TestNotebookRendering:
+    """Rendered-notebook assertions (beyond context dict checks)."""
+
+    def test_rendered_notebook_contains_ensure_target_exists_prologue(self):
+        """The rendered notebook must pre-create the target table before the
+        executor pool starts — this guards against a parallel-CREATE race on
+        the first run (TABLE_OR_VIEW_ALREADY_EXISTS)."""
+        config = _make_project_config()
+        loader = _make_pipeline_config_loader()
+        builder = MonitoringPipelineBuilder(config, pipeline_config_loader=loader)
+        result = builder.build(["bronze", "silver"])
+
+        rendered = builder._render_notebook(
+            sources=result.template_context["sources"],
+            target_fqn=result.template_context["target_fqn"],
+        )
+
+        assert "def _ensure_target_exists()" in rendered
+        assert "_ensure_target_exists()" in rendered
+        assert "from pyspark.sql.utils import AnalysisException" in rendered
+
+        ensure_call_idx = rendered.index("\n    _ensure_target_exists()\n")
+        executor_idx = rendered.index("with ThreadPoolExecutor")
+        assert ensure_call_idx < executor_idx, (
+            "_ensure_target_exists() must be invoked before the "
+            "ThreadPoolExecutor block"
+        )
+
+
 @pytest.mark.unit
 class TestDefaultMvSql:
     """Tests for the default MV SQL template."""


### PR DESCRIPTION
## Summary

- Fix a cold-run race in the monitoring event-log union notebook where `N` parallel streaming queries all called `.toTable(TARGET_TABLE)` and raced to `CREATE` the target Delta table; one thread won and the other `N-1` failed with `TABLE_OR_VIEW_ALREADY_EXISTS`. The generated notebook now pre-creates the target via an idempotent `_ensure_target_exists()` prologue that samples the schema from the first readable source event log.
- Replace the `__eventlog_monitoring` alias in the shared `job_config.yaml` with a dedicated, required `monitoring.job_config_path` pointing at a flat single-document YAML that describes only the monitoring workflow job. `ProjectConfigLoader` validates presence and file existence (deferring tokenized paths to the orchestrator); `JobGenerator.generate_monitoring_job` now takes a resolved `job_config` dict from its caller.
- Version bump: `0.8.2` → `0.8.3`.

## Commits

- `eece4268` — Fix race condition in monitoring event-log union notebook
- `47fc4be9` — Replace `__eventlog_monitoring` alias with dedicated `monitoring.job_config_path`

## Test plan

- [x] `pytest tests/ --ignore=tests/e2e -q` — 3157 passed (unit + integration)
- [x] `pytest tests/e2e/ -q` — 107 passed (includes the 8 monitoring-baseline byte-for-byte comparisons against the re-baselined `union_event_logs.py` fixtures)
- [x] New unit test `TestNotebookRendering::test_rendered_notebook_contains_ensure_target_exists_prologue` asserts the prologue is present and invoked before the `ThreadPoolExecutor` block
- [x] New unit test module `test_monitoring_job_generator.py` covers the `job_config_path` surface
- [x] E2E baseline diff verification: only intended prologue lines changed (`41 insertions(+)` per notebook baseline, zero deletions)
- [x] Runtime verification on a Databricks workspace (out of scope for this PR): drop target table + all checkpoints, run the monitoring job cold, confirm all `N` streams succeed