### PR TITLE
Fix schema hints by quoting columns containing special characters

### DIFF
--- a/src/lhp/parsers/schema_parser.py
+++ b/src/lhp/parsers/schema_parser.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -7,6 +8,9 @@ from ..parsers.yaml_parser import YAMLParser
 
 
 class SchemaParser:
+    # A column name that is safe to emit unquoted in Databricks SQL DDL
+    _SAFE_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self.yaml_parser = YAMLParser()
@@ -62,7 +66,7 @@ class SchemaParser:
         hints = []
         for column in schema_data["columns"]:
             self._require_column_fields(column, schema_name, require_type=True)
-            name = column["name"]
+            name = self._quote_identifier(column["name"])
             col_type = column["type"]
             nullable = column.get("nullable", True)
 
@@ -70,6 +74,20 @@ class SchemaParser:
             hints.append(f"{name} {col_type}{constraint}")
 
         return ", ".join(hints)
+
+    @classmethod
+    def _quote_identifier(cls, name: Any) -> str:
+        """Render a column name as a well-formed Databricks SQL DDL identifier.
+
+        Plain identifiers are returned unchanged so existing schema hints stay stable.
+        Anything else — whitespace, ``$``, or other punctuation — is wrapped in
+        backticks with any embedded backtick doubled, per Spark SQL quoting rules.
+        """
+        name = str(name)
+        if cls._SAFE_IDENTIFIER.match(name):
+            return name
+        escaped = name.replace("`", "``")
+        return f"`{escaped}`"
 
     @staticmethod
     def _require_tag_mapping(raw, column, schema_name) -> Dict[str, Any]:

--- a/tests/unit/test_schema_parser_column_tags.py
+++ b/tests/unit/test_schema_parser_column_tags.py
@@ -1,9 +1,35 @@
 """Unit tests for SchemaParser column-tag extraction and validation."""
 
 import pytest
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import SqlglotError
 
 from lhp.errors import LHPError
 from lhp.parsers.schema_parser import SchemaParser
+
+
+def _assert_well_formed_databricks_ddl(ddl: str, expected_columns: list[str]) -> None:
+    """Assert that a ``to_schema_hints`` fragment is well-formed Databricks SQL.
+
+    The fragment is embedded in a ``CREATE TABLE`` statement and parsed with the
+    ``databricks`` dialect. A parse failure — or column identifiers that do not
+    round-trip to ``expected_columns`` — means the DDL is malformed (e.g. an
+    unquoted identifier containing whitespace or ``$``).
+    """
+    statement = f"CREATE TABLE t ({ddl})"
+    try:
+        parsed = sqlglot.parse_one(statement, read="databricks")
+    except SqlglotError as exc:
+        raise AssertionError(
+            f"schema hints are not well-formed Databricks SQL DDL: {ddl!r} ({exc})"
+        ) from exc
+
+    names = [col.find(exp.Identifier).name for col in parsed.find_all(exp.ColumnDef)]
+    assert names == expected_columns, (
+        f"parsed column identifiers {names} do not round-trip to "
+        f"{expected_columns} for DDL {ddl!r}"
+    )
 
 
 @pytest.mark.unit
@@ -121,3 +147,45 @@ class TestToSchemaHints:
         with pytest.raises(LHPError) as exc_info:
             self.parser.to_schema_hints(schema)
         assert "type" in str(exc_info.value)
+
+    def test_plain_columns_produce_well_formed_ddl(self):
+        # Positive control: ordinary identifiers need no quoting and must parse
+        # as well-formed Databricks SQL DDL. Proves the sqlglot check is sound.
+        schema = {
+            "name": "s",
+            "columns": [
+                {"name": "id", "type": "BIGINT", "nullable": False},
+                {"name": "name", "type": "STRING"},
+            ],
+        }
+        ddl = self.parser.to_schema_hints(schema)
+        _assert_well_formed_databricks_ddl(ddl, ["id", "name"])
+
+    def test_whitespace_column_name_produces_well_formed_ddl(self):
+        # A column name containing whitespace must be emitted as a quoted
+        # identifier so the schema hints remain valid Databricks SQL DDL.
+        schema = {
+            "name": "s",
+            "columns": [{"name": "my column", "type": "STRING"}],
+        }
+        ddl = self.parser.to_schema_hints(schema)
+        _assert_well_formed_databricks_ddl(ddl, ["my column"])
+
+    def test_dollar_column_name_produces_well_formed_ddl(self):
+        # A column name containing `$` must be emitted as a quoted identifier so
+        # the schema hints remain valid Databricks SQL DDL.
+        schema = {
+            "name": "s",
+            "columns": [{"name": "amount$", "type": "STRING"}],
+        }
+        ddl = self.parser.to_schema_hints(schema)
+        _assert_well_formed_databricks_ddl(ddl, ["amount$"])
+
+    def test_whitespace_and_dollar_column_name_produces_well_formed_ddl(self):
+        # Exercises whitespace and `$` in a single identifier.
+        schema = {
+            "name": "s",
+            "columns": [{"name": "gross $ amount", "type": "DECIMAL(18,2)"}],
+        }
+        ddl = self.parser.to_schema_hints(schema)
+        _assert_well_formed_databricks_ddl(ddl, ["gross $ amount"])


### PR DESCRIPTION
Fixes the SchemaParser by adding backtick quoting to column names that contain whitespace or other special characters. It does not add backtick quoting to column names that don't need it (so that existing generated schema hints stay stable).

**Bug:** If a cloudFiles schemaHints is pointed to a YAML/JSON file that specifies column names that contain special characters (e.g., white space), then the SchemaParser produces a mal-formed DDL string, since it does not currently enclose the column name in backtick quotes.

**Context:** One of my customers that is using LHP has files landing that have very messy column names with many spaces and special characters, and so this becomes a problem for them when they want to leverage schema hints.