### PR TITLE
Fix UC tag key validation to allow dots and slashes

### DIFF
--- a/src/lhp/core/codegen/uc_tagging_hook_generator.py
+++ b/src/lhp/core/codegen/uc_tagging_hook_generator.py
@@ -153,8 +153,9 @@ class UCTaggingHookGenerator:
             return substitution_mgr._process_string(text)
         return text
 
-    # UC tag KEYS may not contain any of these six characters.
-    _KEY_PROHIBITED_CHARS = ".,-=/:"
+    # UC tag KEYS may not contain any of these four characters. ('.' and '/' are
+    # permitted: '.' appears in system-governed tag keys and '/' in subdomain keys.)
+    _KEY_PROHIBITED_CHARS = ",-=:"
     _TAG_MAX_LEN = 256
 
     def _normalize_tags(
@@ -184,7 +185,7 @@ class UCTaggingHookGenerator:
     def _validate_tag(cls, key: str, value: str, context: str) -> None:
         """Reject a materialized tag key/value that violates UC's rules.
 
-        KEY: illegal if it contains any of ``. , - = / :``, has leading/trailing
+        KEY: illegal if it contains any of ``, - = :``, has leading/trailing
         whitespace, or exceeds 256 characters. VALUE: illegal if it has
         leading/trailing whitespace or exceeds 256 characters (charset is
         unrestricted). Raises ``LHP-CFG-066`` on the first violation found.
@@ -217,7 +218,7 @@ class UCTaggingHookGenerator:
             title="Illegal UC tag key/value",
             details=f"UC tag {part} {value!r} on {context} is illegal: {reason}.",
             suggestions=[
-                "UC tag keys may not contain any of: . , - = / :",
+                "UC tag keys may not contain any of: , - = :",
                 "Keep keys and values <= 256 chars with no leading/trailing whitespace",
             ],
         )

--- a/tests/unit/test_uc_tagging_hook_generator.py
+++ b/tests/unit/test_uc_tagging_hook_generator.py
@@ -324,6 +324,15 @@ class TestUCTaggingTagValidation:
             _build([action], root=tmp_path)
         assert exc_info.value.code == "LHP-CFG-066"
 
+    @pytest.mark.parametrize("key", ["class.name", "Domain/Subdomain"])
+    def test_key_with_dot_or_slash_is_allowed(self, tmp_path, key):
+        # UC tag keys legitimately contain '.' (system-governed tags) and '/'
+        # (subdomain tags); generation must accept them, not raise LHP-CFG-066.
+        action = _write_action(write_target=_st_target(tags={key: "x"}))
+        content = _build([action], root=tmp_path)[HOOK_FILENAME]
+        # The tag survived normalization into the emitted _TABLE_TAGS map.
+        assert f"{key!r}: 'x'" in content
+
 
 @contextmanager
 def _fake_pyspark_and_sdk(collect_result=None, collect_error=None, do_handler=None):


### PR DESCRIPTION
Fixes UC tag key validation by allowing `.` and `/` characters in tag keys.

**Bug:** Currently, the UC tag validation in LHP rejects any tag keys that contain `.` or `/` characters. If I want to add system-governed tags (e.g., `class.address`) or subdomain tags (e.g., `Finance/Tax`) to my tables or columns, LHP does not currently allow me to do this.
Although these are documented as illegal tag key characters (see: https://docs.databricks.com/aws/en/database-objects/tags#constraints), this documentation appears to be out-dated, as system-governed tags (e.g., `class.name` and `sys.certification_status`) always contain dot characters, and subdomain tags (e.g., `Marketing/Sales`) always contain slash characters.

**See:** https://docs.databricks.com/aws/en/data-governance/unity-catalog/data-classification-tags and https://docs.databricks.com/aws/en/discover/discover-page#what-are-subdomains