### PR TITLE
Fix file-based table_schema validation for SCD2 write targets

### DIFF
--- a/src/lhp/core/loaders/__init__.py
+++ b/src/lhp/core/loaders/__init__.py
@@ -11,6 +11,7 @@ from .job_config_loader import JobConfigLoader
 from .pipeline_config_loader import PipelineConfigLoader
 from .project_config_loader import ProjectConfigLoader
 from .sandbox_profile_loader import load_sandbox_profile
+from .table_schema_resolver import ResolvedTableSchema, resolve_table_schema
 from .version_enforcement import enforce_version_requirements
 
 __all__ = [
@@ -19,9 +20,11 @@ __all__ = [
     "JobConfigLoader",
     "PipelineConfigLoader",
     "ProjectConfigLoader",
+    "ResolvedTableSchema",
     "enforce_version_requirements",
     "is_file_path",
     "load_external_file_text",
     "load_sandbox_profile",
     "resolve_external_file_path",
+    "resolve_table_schema",
 ]

--- a/src/lhp/core/loaders/table_schema_resolver.py
+++ b/src/lhp/core/loaders/table_schema_resolver.py
@@ -1,0 +1,83 @@
+"""Shared resolver for a write target's ``table_schema`` value.
+
+A ``table_schema`` may be inline DDL / a StructType string, or a path to a
+``.yaml``/``.yml``/``.json``/``.ddl``/``.sql`` file. This one resolver turns any of
+those into a schema string, so the streaming-table and materialized-view generators
+and :class:`CdcSchemaValidator` share a single resolution path (no drift). It
+mirrors the branching the generators previously duplicated.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .external_file_loader import (
+    is_file_path,
+    load_external_file_text,
+    resolve_external_file_path,
+)
+
+_YAML_JSON_EXTS = (".yaml", ".yml", ".json")
+
+
+@dataclass
+class ResolvedTableSchema:
+    """Outcome of resolving a ``table_schema`` value.
+
+    ``text`` is the schema string used for code generation and for the CDC
+    ``__START_AT``/``__END_AT`` presence check; it is ``None`` when the value is a
+    file path that could not be resolved (no ``project_root``). ``schema_data`` and
+    ``resolved_path`` are populated only for parsed ``.yaml``/``.yml``/``.json``
+    files, so the generator can run its UC-tag-drop warning.
+    """
+
+    text: Optional[str]
+    schema_data: Optional[Dict[str, Any]] = None
+    resolved_path: Optional[Path] = None
+
+
+def resolve_table_schema(
+    schema_value: Optional[str], project_root: Optional[Path]
+) -> ResolvedTableSchema:
+    """Resolve a ``table_schema`` value to a :class:`ResolvedTableSchema`.
+
+    - inline (not a file path) → ``text`` is the value unchanged.
+    - ``.yaml``/``.yml``/``.json`` file → parsed to schema hints; ``schema_data`` and
+      ``resolved_path`` are populated.
+    - ``.ddl``/``.sql`` file → the file's text, stripped.
+    - a file path with ``project_root`` ``None`` → ``text`` is ``None`` (unresolvable;
+      the caller decides whether to skip).
+
+    Raises :class:`~lhp.errors.LHPError` (e.g. ``LHP-IO-001``) for a referenced but
+    missing/invalid file when ``project_root`` is provided — preserving the
+    generator's error-surfacing. Callers that must not fail wrap this and skip.
+    """
+    if not schema_value:
+        return ResolvedTableSchema(text=None)
+
+    if not is_file_path(schema_value):
+        return ResolvedTableSchema(text=schema_value)
+
+    if project_root is None:
+        return ResolvedTableSchema(text=None)
+
+    if Path(schema_value).suffix.lower() in _YAML_JSON_EXTS:
+        # Deferred, package-level import keeps the loaders package __init__ free of
+        # an eager cross-package (lhp.parsers) import (repo cycle-avoidance convention).
+        from lhp.parsers import SchemaParser
+
+        parser = SchemaParser()
+        resolved_path = resolve_external_file_path(
+            schema_value, project_root, file_type="table schema file"
+        )
+        schema_data = parser.parse_schema_file(resolved_path)
+        return ResolvedTableSchema(
+            text=parser.to_schema_hints(schema_data),
+            schema_data=schema_data,
+            resolved_path=resolved_path,
+        )
+
+    text = load_external_file_text(
+        schema_value, project_root, file_type="table schema file"
+    ).strip()
+    return ResolvedTableSchema(text=text)

--- a/src/lhp/core/validators/action/write.py
+++ b/src/lhp/core/validators/action/write.py
@@ -17,12 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 class WriteActionValidator(BaseActionValidator):
-    def __init__(self, action_registry, field_validator):
+    def __init__(self, action_registry, field_validator, project_root=None):
         super().__init__(action_registry, field_validator)
         self.dlt_validator = DltTableOptionsValidator()
         self.cdc_validator = CdcConfigValidator()
         self.snapshot_cdc_validator = SnapshotCdcConfigValidator()
-        self.cdc_schema_validator = CdcSchemaValidator()
+        self.cdc_schema_validator = CdcSchemaValidator(project_root)
 
     def validate(self, action: Action, prefix: str) -> List[ValidationError]:
         logger.debug(f"Validating write action '{action.name}'")

--- a/src/lhp/core/validators/compatibility/cdc_schema.py
+++ b/src/lhp/core/validators/compatibility/cdc_schema.py
@@ -1,17 +1,42 @@
-from typing import List
+import logging
+from pathlib import Path
+from typing import List, Optional
 
+from lhp.core.loaders import resolve_table_schema
+from lhp.errors import LHPError
 from lhp.models import Action
+
+logger = logging.getLogger(__name__)
 
 
 class CdcSchemaValidator:
+    def __init__(self, project_root: Optional[Path] = None):
+        self.project_root = project_root
+
     def validate(self, action: Action, prefix: str) -> List[str]:
-        errors = []
+        errors: List[str] = []
 
         if not action.write_target:
             return errors
 
-        schema = action.write_target.get("table_schema")
-        if not schema:
+        schema_value = action.write_target.get("table_schema")
+        if not schema_value:
+            return errors
+
+        # Resolve a file-based table_schema (schemas/*.yaml, *.ddl, ...) to its
+        # actual schema text before checking for the SCD2 history columns; a raw
+        # path string would otherwise never contain __START_AT/__END_AT.
+        try:
+            resolved = resolve_table_schema(schema_value, self.project_root)
+        except LHPError as e:
+            # Missing/invalid schema file — the generator surfaces the real IO
+            # error later; skip here rather than false-positive or double-report.
+            logger.debug("CDC schema resolution deferred to generator: %s", e)
+            return errors
+
+        schema = resolved.text
+        if schema is None:
+            # File path with no project_root to resolve against — defer.
             return errors
 
         if "__START_AT" not in schema:

--- a/src/lhp/core/validators/config_validator.py
+++ b/src/lhp/core/validators/config_validator.py
@@ -66,7 +66,7 @@ class ConfigValidator:
             self.project_config,
         )
         self.write_validator = WriteActionValidator(
-            self.action_registry, self.field_validator
+            self.action_registry, self.field_validator, self.project_root
         )
         self.test_validator = TestActionValidator(
             self.action_registry, self.field_validator

--- a/src/lhp/generators/write/materialized_view.py
+++ b/src/lhp/generators/write/materialized_view.py
@@ -5,14 +5,10 @@ from pathlib import Path
 
 from lhp.models import Action
 
-from ...core.loaders.external_file_loader import (
-    is_file_path,
-    load_external_file_text,
-    resolve_external_file_path,
-)
+from ...core.loaders import resolve_table_schema
+from ...core.loaders.external_file_loader import load_external_file_text
 from ...core.registry import BaseActionGenerator
 from ...errors import ErrorFactory, codes
-from ...parsers.schema_parser import SchemaParser
 from ._schema_tags_warning import warn_if_schema_tags_dropped
 
 logger = logging.getLogger(__name__)
@@ -25,7 +21,6 @@ class MaterializedViewWriteGenerator(BaseActionGenerator):
         super().__init__()
         self.add_import("from pyspark import pipelines as dp")
         self.add_import("from pyspark.sql import DataFrame")
-        self.schema_parser = SchemaParser()
 
     def generate(self, action: Action, context: dict) -> str:
         target_config = action.write_target
@@ -62,25 +57,16 @@ class MaterializedViewWriteGenerator(BaseActionGenerator):
         schema = None
 
         if schema_value:
-            if is_file_path(schema_value):
-                project_root = context.get("project_root", Path.cwd())
-                file_ext = Path(schema_value).suffix.lower()
-
-                if file_ext in [".yaml", ".yml", ".json"]:
-                    resolved_path = resolve_external_file_path(
-                        schema_value, project_root, file_type="table schema file"
-                    )
-                    schema_data = self.schema_parser.parse_schema_file(resolved_path)
-                    warn_if_schema_tags_dropped(
-                        schema_data, target_config, resolved_path, project_root
-                    )
-                    schema = self.schema_parser.to_schema_hints(schema_data)
-                else:
-                    schema = load_external_file_text(
-                        schema_value, project_root, file_type="table schema file"
-                    ).strip()
-            else:
-                schema = schema_value
+            project_root = context.get("project_root", Path.cwd())
+            resolved = resolve_table_schema(schema_value, project_root)
+            schema = resolved.text
+            if resolved.schema_data is not None:
+                warn_if_schema_tags_dropped(
+                    resolved.schema_data,
+                    target_config,
+                    resolved.resolved_path,
+                    project_root,
+                )
 
         row_filter = target_config.get("row_filter")
         temporary = target_config.get("temporary", False)

--- a/src/lhp/generators/write/streaming_table.py
+++ b/src/lhp/generators/write/streaming_table.py
@@ -7,15 +7,10 @@ from typing import Any, Dict, List
 from lhp.models import Action
 
 from ...core.codegen import copy_user_module_for_pipeline
-from ...core.loaders.external_file_loader import (
-    is_file_path,
-    load_external_file_text,
-    resolve_external_file_path,
-)
+from ...core.loaders import resolve_table_schema
 from ...core.processing.dqe import DQEParser
 from ...core.registry import BaseActionGenerator
 from ...errors import ErrorFactory
-from ...parsers.schema_parser import SchemaParser
 from ._schema_tags_warning import warn_if_schema_tags_dropped
 from .snapshot_cdc_source_function import (
     SourceFunctionResult,
@@ -29,7 +24,6 @@ class StreamingTableWriteGenerator(BaseActionGenerator):
     def __init__(self):
         super().__init__()
         self.add_import("from pyspark import pipelines as dp")
-        self.schema_parser = SchemaParser()
 
     def generate(self, action: Action, context: dict) -> str:
         target_config = action.write_target
@@ -81,25 +75,16 @@ class StreamingTableWriteGenerator(BaseActionGenerator):
         schema = None
 
         if schema_value:
-            if is_file_path(schema_value):
-                project_root = context.get("project_root", Path.cwd())
-                file_ext = Path(schema_value).suffix.lower()
-
-                if file_ext in [".yaml", ".yml", ".json"]:
-                    resolved_path = resolve_external_file_path(
-                        schema_value, project_root, file_type="table schema file"
-                    )
-                    schema_data = self.schema_parser.parse_schema_file(resolved_path)
-                    warn_if_schema_tags_dropped(
-                        schema_data, target_config, resolved_path, project_root
-                    )
-                    schema = self.schema_parser.to_schema_hints(schema_data)
-                else:
-                    schema = load_external_file_text(
-                        schema_value, project_root, file_type="table schema file"
-                    ).strip()
-            else:
-                schema = schema_value
+            project_root = context.get("project_root", Path.cwd())
+            resolved = resolve_table_schema(schema_value, project_root)
+            schema = resolved.text
+            if resolved.schema_data is not None:
+                warn_if_schema_tags_dropped(
+                    resolved.schema_data,
+                    target_config,
+                    resolved.resolved_path,
+                    project_root,
+                )
 
         row_filter = target_config.get("row_filter")
         temporary = target_config.get("temporary", False)

--- a/tests/core/loaders/test_table_schema_resolver.py
+++ b/tests/core/loaders/test_table_schema_resolver.py
@@ -1,0 +1,80 @@
+"""Unit tests for the shared `table_schema` resolver.
+
+`resolve_table_schema` turns a write target's ``table_schema`` value — inline DDL /
+StructType, or a ``.yaml``/``.yml``/``.json``/``.ddl``/``.sql`` file path — into a
+schema string (plus parsed data for YAML/JSON). It is shared by the streaming-table
+and materialized-view generators and by ``CdcSchemaValidator``.
+"""
+
+import pytest
+
+from lhp.core.loaders import ResolvedTableSchema, resolve_table_schema
+from lhp.errors import LHPError
+
+_SCHEMA_YAML = """\
+name: customer_scd2_dim
+columns:
+  - name: customer_id
+    type: BIGINT
+  - name: __START_AT
+    type: TIMESTAMP
+  - name: __END_AT
+    type: TIMESTAMP
+"""
+
+
+class TestResolveTableSchema:
+    def test_inline_ddl_passthrough(self):
+        """A non-file value is returned unchanged as text, with no schema_data."""
+        resolved = resolve_table_schema(
+            "id INT, __START_AT TIMESTAMP, __END_AT TIMESTAMP", project_root=None
+        )
+        assert isinstance(resolved, ResolvedTableSchema)
+        assert resolved.text == "id INT, __START_AT TIMESTAMP, __END_AT TIMESTAMP"
+        assert resolved.schema_data is None
+        assert resolved.resolved_path is None
+
+    def test_empty_value_returns_none_text(self):
+        resolved = resolve_table_schema("", project_root=None)
+        assert resolved.text is None
+
+    def test_yaml_file_parsed_to_hints(self, tmp_path):
+        """A YAML file is parsed to schema hints; schema_data + resolved_path are populated."""
+        schemas = tmp_path / "schemas"
+        schemas.mkdir()
+        (schemas / "customer_scd2_dim.yaml").write_text(_SCHEMA_YAML)
+
+        resolved = resolve_table_schema(
+            "schemas/customer_scd2_dim.yaml", project_root=tmp_path
+        )
+        assert "__START_AT" in resolved.text
+        assert "__END_AT" in resolved.text
+        assert "customer_id" in resolved.text
+        assert resolved.schema_data is not None
+        assert {c["name"] for c in resolved.schema_data["columns"]} == {
+            "customer_id",
+            "__START_AT",
+            "__END_AT",
+        }
+        assert resolved.resolved_path == (schemas / "customer_scd2_dim.yaml")
+
+    def test_ddl_file_returns_stripped_text(self, tmp_path):
+        """A .sql/.ddl file returns its text (stripped), with no schema_data."""
+        (tmp_path / "customer.sql").write_text(
+            "  id INT, __START_AT TIMESTAMP, __END_AT TIMESTAMP\n"
+        )
+        resolved = resolve_table_schema("customer.sql", project_root=tmp_path)
+        assert resolved.text == "id INT, __START_AT TIMESTAMP, __END_AT TIMESTAMP"
+        assert resolved.schema_data is None
+
+    def test_file_path_without_project_root_is_unresolvable(self):
+        """A file path but no project_root yields text=None (caller decides)."""
+        resolved = resolve_table_schema(
+            "schemas/customer_scd2_dim.yaml", project_root=None
+        )
+        assert resolved.text is None
+
+    def test_missing_file_raises(self, tmp_path):
+        """A referenced-but-missing file raises LHPError (generator surfaces it)."""
+        with pytest.raises(LHPError):
+            resolve_table_schema("schemas/nope.yaml", project_root=tmp_path)

--- a/tests/core/validators/compatibility/test_cdc_schema.py
+++ b/tests/core/validators/compatibility/test_cdc_schema.py
@@ -1,0 +1,91 @@
+"""Unit tests for `CdcSchemaValidator` with a file-based ``table_schema``.
+
+The inline-DDL behavior is covered by
+``tests/test_dlt_cdc_validators_extended.py::TestCdcSchemaValidatorDirect``. These
+tests cover the file-reference form: the validator resolves the schema file (relative
+to ``project_root``) before checking for the SCD2 history columns ``__START_AT`` /
+``__END_AT``, and defers (no false positives) when it cannot resolve.
+"""
+
+from lhp.core.validators.compatibility import CdcSchemaValidator
+from lhp.models import Action, ActionType
+
+_BOTH_COLUMNS = """\
+name: customer_scd2_dim
+columns:
+  - name: customer_id
+    type: BIGINT
+  - name: __START_AT
+    type: TIMESTAMP
+  - name: __END_AT
+    type: TIMESTAMP
+"""
+
+_MISSING_START_AT = """\
+name: customer_scd2_dim
+columns:
+  - name: customer_id
+    type: BIGINT
+  - name: __END_AT
+    type: TIMESTAMP
+"""
+
+_MISSING_BOTH = """\
+name: customer_scd2_dim
+columns:
+  - name: customer_id
+    type: BIGINT
+  - name: c_name
+    type: STRING
+"""
+
+
+def _write_schema(tmp_path, body):
+    schemas = tmp_path / "schemas"
+    schemas.mkdir(exist_ok=True)
+    (schemas / "customer_scd2_dim.yaml").write_text(body)
+    return "schemas/customer_scd2_dim.yaml"
+
+
+def _action(schema_ref):
+    return Action(
+        name="write_customer_scd2",
+        type=ActionType.WRITE,
+        source="v_source",
+        write_target={"type": "streaming_table", "table_schema": schema_ref},
+    )
+
+
+class TestCdcSchemaValidatorFileSchema:
+    prefix = "Action[1] 'write_customer_scd2'"
+
+    def test_file_schema_with_both_columns_no_errors(self, tmp_path):
+        ref = _write_schema(tmp_path, _BOTH_COLUMNS)
+        validator = CdcSchemaValidator(project_root=tmp_path)
+        assert validator.validate(_action(ref), self.prefix) == []
+
+    def test_file_schema_missing_start_at(self, tmp_path):
+        ref = _write_schema(tmp_path, _MISSING_START_AT)
+        validator = CdcSchemaValidator(project_root=tmp_path)
+        errors = validator.validate(_action(ref), self.prefix)
+        assert any("__START_AT" in e for e in errors)
+        assert not any("__END_AT" in e for e in errors)
+
+    def test_file_schema_missing_both_columns(self, tmp_path):
+        ref = _write_schema(tmp_path, _MISSING_BOTH)
+        validator = CdcSchemaValidator(project_root=tmp_path)
+        errors = validator.validate(_action(ref), self.prefix)
+        assert any("__START_AT" in e for e in errors)
+        assert any("__END_AT" in e for e in errors)
+        assert len(errors) == 2
+
+    def test_file_schema_no_project_root_defers(self, tmp_path):
+        """File path but no project_root: cannot resolve → defer, no false positive."""
+        _write_schema(tmp_path, _MISSING_BOTH)
+        validator = CdcSchemaValidator(project_root=None)
+        assert validator.validate(_action("schemas/customer_scd2_dim.yaml"), self.prefix) == []
+
+    def test_missing_schema_file_defers(self, tmp_path):
+        """Referenced file does not exist: defer to the generator's IO error, do not raise."""
+        validator = CdcSchemaValidator(project_root=tmp_path)
+        assert validator.validate(_action("schemas/does_not_exist.yaml"), self.prefix) == []

--- a/tests/core/validators/compatibility/test_cdc_schema.py
+++ b/tests/core/validators/compatibility/test_cdc_schema.py
@@ -83,9 +83,15 @@ class TestCdcSchemaValidatorFileSchema:
         """File path but no project_root: cannot resolve → defer, no false positive."""
         _write_schema(tmp_path, _MISSING_BOTH)
         validator = CdcSchemaValidator(project_root=None)
-        assert validator.validate(_action("schemas/customer_scd2_dim.yaml"), self.prefix) == []
+        assert (
+            validator.validate(_action("schemas/customer_scd2_dim.yaml"), self.prefix)
+            == []
+        )
 
     def test_missing_schema_file_defers(self, tmp_path):
         """Referenced file does not exist: defer to the generator's IO error, do not raise."""
         validator = CdcSchemaValidator(project_root=tmp_path)
-        assert validator.validate(_action("schemas/does_not_exist.yaml"), self.prefix) == []
+        assert (
+            validator.validate(_action("schemas/does_not_exist.yaml"), self.prefix)
+            == []
+        )

--- a/tests/e2e/test_cdc_scd2_schema_file_e2e.py
+++ b/tests/e2e/test_cdc_scd2_schema_file_e2e.py
@@ -1,0 +1,149 @@
+"""E2E golden test: SCD2 CDC write target with a file-based ``table_schema``.
+
+Exercises a streaming-table write target in ``mode: cdc`` / ``scd_type: 2`` whose
+``table_schema`` points at a YAML schema file that already contains the DLT-required
+``__START_AT`` / ``__END_AT`` history columns — proving the full path from YAML through
+validation to generated Python works.
+
+The pipeline and its schema file are injected into an isolated *copy* of the shared
+fixture project at runtime (never committed to the shared fixture), so this test does
+not perturb the whole-project baselines other e2e suites compare against.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from lhp.cli.main import cli
+
+_SCHEMA_FILE = """\
+name: customer_scd2_dim
+version: "1.0"
+description: "Customer SCD2 dimension schema (with __START_AT/__END_AT)"
+columns:
+  - name: customer_id
+    type: BIGINT
+    nullable: false
+    comment: "Customer key - CDC key"
+  - name: c_name
+    type: STRING
+    nullable: true
+  - name: c_address
+    type: STRING
+    nullable: true
+  - name: last_modified_dt
+    type: TIMESTAMP
+    nullable: true
+    comment: "CDC sequence_by column"
+  - name: __START_AT
+    type: TIMESTAMP
+    nullable: true
+    comment: "SCD2 history start (same type as sequence_by)"
+  - name: __END_AT
+    type: TIMESTAMP
+    nullable: true
+    comment: "SCD2 history end (same type as sequence_by)"
+"""
+
+_FLOWGROUP = """\
+pipeline: 22_cdc_scd2_schema
+flowgroup: cdc_scd2_schema_file
+actions:
+  - name: load_customer_bronze
+    type: load
+    readMode: stream
+    source:
+      type: delta
+      database: "{catalog}.{bronze_schema}"
+      table: customer
+    target: v_customer_bronze
+    description: "Stream customer table from the bronze schema"
+
+  - name: write_customer_scd2
+    type: write
+    source: v_customer_bronze
+    write_target:
+      type: streaming_table
+      database: "{catalog}.{silver_schema}"
+      table: customer_scd2_dim
+      mode: cdc
+      table_schema: "schemas/customer_scd2_dim.yaml"
+      cdc_config:
+        keys: ["customer_id"]
+        sequence_by: "last_modified_dt"
+        scd_type: 2
+"""
+
+
+@pytest.mark.e2e
+class TestCdcScd2SchemaFileE2E:
+    """E2E test for SCD2 CDC with a YAML-file ``table_schema``."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test_project(self, isolated_project):
+        fixture_path = Path(__file__).parent / "fixtures" / "testing_project"
+        self.project_root = isolated_project / "test_project"
+        shutil.copytree(fixture_path, self.project_root)
+
+        self.original_cwd = os.getcwd()
+        os.chdir(self.project_root)
+
+        self.generated_dir = self.project_root / "generated" / "dev"
+        self.resources_dir = self.project_root / "resources" / "lhp"
+
+        self._init_bundle_project()
+
+        # Inject the pipeline + schema file under test into THIS copy only, so the
+        # shared committed fixture (and every whole-project baseline) is untouched.
+        (self.project_root / "schemas" / "customer_scd2_dim.yaml").write_text(_SCHEMA_FILE)
+        pipeline_dir = self.project_root / "pipelines" / "22_cdc_scd2_schema"
+        pipeline_dir.mkdir(parents=True, exist_ok=True)
+        (pipeline_dir / "cdc_scd2_schema_file.yaml").write_text(_FLOWGROUP)
+
+        yield
+        os.chdir(self.original_cwd)
+
+    def _init_bundle_project(self):
+        if self.generated_dir.exists():
+            shutil.rmtree(self.generated_dir)
+        if self.resources_dir.exists():
+            shutil.rmtree(self.resources_dir)
+        self.generated_dir.mkdir(parents=True, exist_ok=True)
+        self.resources_dir.mkdir(parents=True, exist_ok=True)
+
+    def run_generate(self) -> tuple:
+        """Run 'lhp generate --env dev' (no --include-tests)."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "--env",
+                "dev",
+                "--pipeline-config",
+                "config/pipeline_config.yaml",
+            ],
+        )
+        return result.exit_code, result.output
+
+    def test_scd2_cdc_with_yaml_table_schema_file(self):
+        """SCD2 CDC write target whose table_schema is a YAML file reference generates cleanly."""
+        exit_code, output = self.run_generate()
+        assert exit_code == 0, f"Generation failed:\n{output}"
+
+        generated = self.generated_dir / "22_cdc_scd2_schema" / "cdc_scd2_schema_file.py"
+        assert generated.exists(), (
+            "cdc_scd2_schema_file.py should be generated under 22_cdc_scd2_schema/"
+        )
+
+        # Constructive assertions: the file-based table_schema (incl. __START_AT /
+        # __END_AT) is resolved and emitted, and the SCD2 CDC flow is generated.
+        text = generated.read_text()
+        assert "dp.create_streaming_table(" in text
+        assert "dp.create_auto_cdc_flow(" in text
+        assert "stored_as_scd_type=2" in text
+        assert "__START_AT" in text
+        assert "__END_AT" in text

--- a/tests/e2e/test_cdc_scd2_schema_file_e2e.py
+++ b/tests/e2e/test_cdc_scd2_schema_file_e2e.py
@@ -98,7 +98,9 @@ class TestCdcScd2SchemaFileE2E:
 
         # Inject the pipeline + schema file under test into THIS copy only, so the
         # shared committed fixture (and every whole-project baseline) is untouched.
-        (self.project_root / "schemas" / "customer_scd2_dim.yaml").write_text(_SCHEMA_FILE)
+        (self.project_root / "schemas" / "customer_scd2_dim.yaml").write_text(
+            _SCHEMA_FILE
+        )
         pipeline_dir = self.project_root / "pipelines" / "22_cdc_scd2_schema"
         pipeline_dir.mkdir(parents=True, exist_ok=True)
         (pipeline_dir / "cdc_scd2_schema_file.yaml").write_text(_FLOWGROUP)
@@ -134,7 +136,9 @@ class TestCdcScd2SchemaFileE2E:
         exit_code, output = self.run_generate()
         assert exit_code == 0, f"Generation failed:\n{output}"
 
-        generated = self.generated_dir / "22_cdc_scd2_schema" / "cdc_scd2_schema_file.py"
+        generated = (
+            self.generated_dir / "22_cdc_scd2_schema" / "cdc_scd2_schema_file.py"
+        )
         assert generated.exists(), (
             "cdc_scd2_schema_file.py should be generated under 22_cdc_scd2_schema/"
         )

--- a/tests/test_config_validator_dlt_cdc.py
+++ b/tests/test_config_validator_dlt_cdc.py
@@ -7,6 +7,48 @@ from lhp.models import Action, ActionType
 
 
 class TestConfigValidatorDltCdc:
+    def test_cdc_scd2_file_table_schema_wiring(self, tmp_path):
+        """End-to-end wiring: a CDC SCD2 write target whose table_schema is a YAML
+        file (with __START_AT/__END_AT) validates cleanly once project_root is
+        threaded ConfigValidator -> WriteActionValidator -> CdcSchemaValidator."""
+        schemas = tmp_path / "schemas"
+        schemas.mkdir()
+        (schemas / "customer_scd2_dim.yaml").write_text(
+            "name: customer_scd2_dim\n"
+            "columns:\n"
+            "  - name: customer_id\n"
+            "    type: BIGINT\n"
+            "  - name: last_modified_dt\n"
+            "    type: TIMESTAMP\n"
+            "  - name: __START_AT\n"
+            "    type: TIMESTAMP\n"
+            "  - name: __END_AT\n"
+            "    type: TIMESTAMP\n"
+        )
+
+        validator = ConfigValidator(project_root=tmp_path)
+        action = Action(
+            name="write_customer_scd2",
+            type=ActionType.WRITE,
+            source="v_customer_bronze",
+            write_target={
+                "type": "streaming_table",
+                "catalog": "cat",
+                "schema": "silver",
+                "table": "customer_scd2_dim",
+                "mode": "cdc",
+                "table_schema": "schemas/customer_scd2_dim.yaml",
+                "cdc_config": {
+                    "keys": ["customer_id"],
+                    "sequence_by": "last_modified_dt",
+                    "scd_type": 2,
+                },
+            },
+        )
+        errors = validator.validate_action(action, 1)
+        assert not any("__START_AT" in str(e) for e in errors), errors
+        assert not any("__END_AT" in str(e) for e in errors), errors
+
     def test_dlt_table_options_validation_comprehensive(self):
         validator = ConfigValidator()
 


### PR DESCRIPTION
An SCD Type 2 CDC streaming-table write target whose schema is supplied via a file reference (`table_schema: "schemas/customer_scd2_dim.yaml"`) failed both `lhp validate` and `lhp generate` with two false errors, even when the file correctly declared the SCD2 history columns:

`Action[1] 'write_customer_scd2': CDC schema must include '__START_AT' column with same type as sequence_by`
`Action[1] 'write_customer_scd2': CDC schema must include '__END_AT' column with same type as sequence_by`

**Root cause:** `CdcSchemaValidator` did a substring check on the raw `table_schema` value. For a file path, `"__START_AT" in "schemas/customer_scd2_dim.yaml"` is always false, so it flagged the columns as missing without ever reading the file. Inline DDL worked (the substring is literally present); only the file-reference form was broken. The check runs during validation, before the generator resolves the file; and the generator already resolved file-based `table_schema` correctly, so the two layers disagreed.

**Fix**
- New shared resolver `resolve_table_schema(value, project_root)` in `core/loaders/` turns inline DDL, a .yaml/.yml/.json file, or a .ddl/.sql file into a schema string (plus parsed data). The streaming table and materialized view generators previously duplicated this branch; both now call the resolver, and so does the validator - one resolution path, no drift.
- `CdcSchemaValidator` resolves a file-based `table_schema` before the `__START_AT`/`__END_AT` presence check. It defers (no false positive) when it can't resolve - no `project_root`, or a missing/invalid file whose real IO error the generator surfaces later.
- `project_root` threaded `ConfigValidator` → `WriteActionValidator` → `CdcSchemaValidator`, mirroring the existing `TransformActionValidator` wiring.