### PR TITLE
Fix CdcSchemaValidator to only validate SCD Type 2 targets

### DIFF
--- a/src/lhp/core/validators/compatibility/cdc_schema.py
+++ b/src/lhp/core/validators/compatibility/cdc_schema.py
@@ -23,6 +23,14 @@ class CdcSchemaValidator:
         if not schema_value:
             return errors
 
+        # Only SCD Type 2 carries the __START_AT/__END_AT validity columns; a Type 1
+        # target must not declare them (the runtime rejects it), so the presence check
+        # does not apply. Mirror the generator, which derives stored_as_scd_type from
+        # cdc_config['scd_type'] and defaults to 1 (templates/write/streaming_table.py.j2).
+        cdc_config = action.write_target.get("cdc_config") or {}
+        if cdc_config.get("scd_type", 1) != 2:
+            return errors
+
         # Resolve a file-based table_schema (schemas/*.yaml, *.ddl, ...) to its
         # actual schema text before checking for the SCD2 history columns; a raw
         # path string would otherwise never contain __START_AT/__END_AT.

--- a/tests/core/validators/compatibility/test_cdc_schema.py
+++ b/tests/core/validators/compatibility/test_cdc_schema.py
@@ -47,12 +47,28 @@ def _write_schema(tmp_path, body):
     return "schemas/customer_scd2_dim.yaml"
 
 
-def _action(schema_ref):
+def _action(schema_ref, cdc_config=None):
+    """Build a CDC write action referencing ``schema_ref``.
+
+    The ``__START_AT``/``__END_AT`` presence check only applies to SCD Type 2, so
+    the default ``cdc_config`` is Type 2; pass an explicit ``cdc_config`` (e.g. with
+    ``scd_type: 1``) to exercise the gate.
+    """
+    if cdc_config is None:
+        cdc_config = {
+            "keys": ["customer_id"],
+            "sequence_by": "last_modified_dt",
+            "scd_type": 2,
+        }
     return Action(
         name="write_customer_scd2",
         type=ActionType.WRITE,
         source="v_source",
-        write_target={"type": "streaming_table", "table_schema": schema_ref},
+        write_target={
+            "type": "streaming_table",
+            "table_schema": schema_ref,
+            "cdc_config": cdc_config,
+        },
     )
 
 
@@ -95,3 +111,74 @@ class TestCdcSchemaValidatorFileSchema:
             validator.validate(_action("schemas/does_not_exist.yaml"), self.prefix)
             == []
         )
+
+
+# Inline DDL with a PRIMARY KEY and no __START_AT/__END_AT — correct for SCD Type 1,
+# where the validity columns must not exist. ``table_schema`` is the only way to
+# register a PRIMARY KEY on a pipeline-managed table.
+_SCD1_INLINE = (
+    "customer_sk STRING NOT NULL, customer_id BIGINT NOT NULL, "
+    "c_name STRING, CONSTRAINT dim_customer_pk PRIMARY KEY (customer_sk)"
+)
+
+
+class TestCdcSchemaValidatorScdType:
+    """The ``__START_AT``/``__END_AT`` presence check applies to SCD Type 2 only.
+
+    Type 1 targets must not carry the validity columns (the runtime rejects them),
+    so declaring a PRIMARY KEY via ``table_schema`` on a Type 1 target must validate.
+    """
+
+    prefix = "Action[1] 'write_customer_scd2'"
+
+    def test_scd1_inline_schema_with_primary_key_no_errors(self):
+        """SCD1 + PRIMARY KEY, no validity columns: no error."""
+        validator = CdcSchemaValidator()
+        action = _action(
+            _SCD1_INLINE,
+            cdc_config={
+                "keys": ["customer_id"],
+                "sequence_by": "last_modified_dt",
+                "scd_type": 1,
+            },
+        )
+        assert validator.validate(action, self.prefix) == []
+
+    def test_scd_type_omitted_defaults_to_type1_no_errors(self):
+        """Omitted scd_type defaults to Type 1 (matching the generator): no error."""
+        validator = CdcSchemaValidator()
+        action = _action(
+            _SCD1_INLINE,
+            cdc_config={"keys": ["customer_id"], "sequence_by": "last_modified_dt"},
+        )
+        assert validator.validate(action, self.prefix) == []
+
+    def test_scd1_file_schema_with_primary_key_no_errors(self, tmp_path):
+        """SCD1 + a file-based schema with no validity columns: no error."""
+        ref = _write_schema(tmp_path, _MISSING_BOTH)
+        validator = CdcSchemaValidator(project_root=tmp_path)
+        action = _action(
+            ref,
+            cdc_config={
+                "keys": ["customer_id"],
+                "sequence_by": "last_modified_dt",
+                "scd_type": 1,
+            },
+        )
+        assert validator.validate(action, self.prefix) == []
+
+    def test_scd2_still_requires_validity_columns(self):
+        """Regression guard: SCD2 missing both validity columns still errors."""
+        validator = CdcSchemaValidator()
+        action = _action(
+            _SCD1_INLINE,
+            cdc_config={
+                "keys": ["customer_id"],
+                "sequence_by": "last_modified_dt",
+                "scd_type": 2,
+            },
+        )
+        errors = validator.validate(action, self.prefix)
+        assert any("__START_AT" in e for e in errors)
+        assert any("__END_AT" in e for e in errors)
+        assert len(errors) == 2

--- a/tests/e2e/test_cdc_scd1_primary_key_e2e.py
+++ b/tests/e2e/test_cdc_scd1_primary_key_e2e.py
@@ -1,0 +1,191 @@
+"""E2E golden test: SCD1 CDC write target that declares a PRIMARY KEY via ``table_schema``.
+
+Exercises a streaming-table write target in ``mode: cdc`` / ``scd_type: 1`` whose
+``table_schema`` contains a ``CONSTRAINT ... PRIMARY KEY`` and, correctly for Type 1, *no*
+``__START_AT`` / ``__END_AT`` history columns. This is the reported case: ``table_schema`` is
+the only way to register a PRIMARY KEY on a pipeline-managed table, but the schema validator
+used to demand the SCD2 validity columns for every ``mode: cdc`` target, so an SCD1 dimension
+could never declare a PK. Both the inline-DDL form (the reported reproduction) and the
+file-reference form are covered — the latter proves the resolver path is gated too and the old
+"tokens in the filename" workaround is no longer needed.
+
+The pipeline and its schema are injected into an isolated *copy* of the shared fixture project
+at runtime (never committed to the shared fixture), so this test does not perturb the
+whole-project baselines other e2e suites compare against.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from lhp.cli.main import cli
+
+# Inline DDL: surrogate-key PRIMARY KEY, business key, one attribute — and no
+# __START_AT/__END_AT (those must not exist on an SCD Type 1 target).
+_INLINE_SCHEMA = (
+    "customer_sk STRING NOT NULL,\n"
+    "customer_id BIGINT NOT NULL,\n"
+    "c_name STRING,\n"
+    "CONSTRAINT dim_customer_pk PRIMARY KEY (customer_sk)"
+)
+
+_INLINE_FLOWGROUP = """\
+pipeline: 23_cdc_scd1_pk
+flowgroup: cdc_scd1_pk_inline
+actions:
+  - name: load_customer_bronze
+    type: load
+    readMode: stream
+    source:
+      type: delta
+      database: "{catalog}.{bronze_schema}"
+      table: customer
+    target: v_customer_bronze
+    description: "Stream customer table from the bronze schema"
+
+  - name: write_dim_customer
+    type: write
+    source: v_customer_bronze
+    write_target:
+      type: streaming_table
+      database: "{catalog}.{silver_schema}"
+      table: dim_customer_scd1_inline
+      mode: cdc
+      cdc_config:
+        keys: ["customer_id"]
+        sequence_by: "last_modified_dt"
+        scd_type: 1
+      table_schema: |
+        customer_sk STRING NOT NULL,
+        customer_id BIGINT NOT NULL,
+        c_name STRING,
+        CONSTRAINT dim_customer_pk PRIMARY KEY (customer_sk)
+"""
+
+# A ``.ddl`` sidecar with the same PK-bearing, validity-column-free schema.
+_DDL_SCHEMA_FILE = _INLINE_SCHEMA + "\n"
+
+_FILE_FLOWGROUP = """\
+pipeline: 23_cdc_scd1_pk
+flowgroup: cdc_scd1_pk_file
+actions:
+  - name: load_customer_bronze_file
+    type: load
+    readMode: stream
+    source:
+      type: delta
+      database: "{catalog}.{bronze_schema}"
+      table: customer
+    target: v_customer_bronze_file
+    description: "Stream customer table from the bronze schema"
+
+  - name: write_dim_customer_file
+    type: write
+    source: v_customer_bronze_file
+    write_target:
+      type: streaming_table
+      database: "{catalog}.{silver_schema}"
+      table: dim_customer_scd1_file
+      mode: cdc
+      cdc_config:
+        keys: ["customer_id"]
+        sequence_by: "last_modified_dt"
+        scd_type: 1
+      table_schema: "schemas/dim_customer_scd1.ddl"
+"""
+
+
+@pytest.mark.e2e
+class TestCdcScd1PrimaryKeyE2E:
+    """E2E test for an SCD1 CDC write target declaring a PRIMARY KEY via ``table_schema``."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test_project(self, isolated_project):
+        fixture_path = Path(__file__).parent / "fixtures" / "testing_project"
+        self.project_root = isolated_project / "test_project"
+        shutil.copytree(fixture_path, self.project_root)
+
+        self.original_cwd = os.getcwd()
+        os.chdir(self.project_root)
+
+        self.generated_dir = self.project_root / "generated" / "dev"
+        self.resources_dir = self.project_root / "resources" / "lhp"
+
+        self._init_bundle_project()
+
+        # Inject the pipeline(s) + schema file under test into THIS copy only, so the
+        # shared committed fixture (and every whole-project baseline) is untouched.
+        pipeline_dir = self.project_root / "pipelines" / "23_cdc_scd1_pk"
+        pipeline_dir.mkdir(parents=True, exist_ok=True)
+        (pipeline_dir / "cdc_scd1_pk_inline.yaml").write_text(_INLINE_FLOWGROUP)
+        (pipeline_dir / "cdc_scd1_pk_file.yaml").write_text(_FILE_FLOWGROUP)
+        (self.project_root / "schemas" / "dim_customer_scd1.ddl").write_text(
+            _DDL_SCHEMA_FILE
+        )
+
+        yield
+        os.chdir(self.original_cwd)
+
+    def _init_bundle_project(self):
+        if self.generated_dir.exists():
+            shutil.rmtree(self.generated_dir)
+        if self.resources_dir.exists():
+            shutil.rmtree(self.resources_dir)
+        self.generated_dir.mkdir(parents=True, exist_ok=True)
+        self.resources_dir.mkdir(parents=True, exist_ok=True)
+
+    def run_generate(self) -> tuple:
+        """Run 'lhp generate --env dev' (no --include-tests)."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "--env",
+                "dev",
+                "--pipeline-config",
+                "config/pipeline_config.yaml",
+            ],
+        )
+        return result.exit_code, result.output
+
+    def test_scd1_cdc_inline_schema_with_primary_key(self):
+        """Inline table_schema with a PRIMARY KEY and no validity columns generates cleanly."""
+        exit_code, output = self.run_generate()
+        assert exit_code == 0, f"Generation failed:\n{output}"
+
+        generated = self.generated_dir / "23_cdc_scd1_pk" / "cdc_scd1_pk_inline.py"
+        assert generated.exists(), (
+            "cdc_scd1_pk_inline.py should be generated under 23_cdc_scd1_pk/"
+        )
+
+        text = generated.read_text()
+        assert "dp.create_streaming_table(" in text
+        assert "dp.create_auto_cdc_flow(" in text
+        assert "stored_as_scd_type=1" in text
+        # The PRIMARY KEY constraint is preserved in the emitted schema.
+        assert "PRIMARY KEY" in text
+        # SCD Type 1 must not carry the SCD2 history/validity columns.
+        assert "__START_AT" not in text
+        assert "__END_AT" not in text
+
+    def test_scd1_cdc_file_schema_with_primary_key(self):
+        """A file-based (.ddl) table_schema with a PRIMARY KEY is resolved and gated too."""
+        exit_code, output = self.run_generate()
+        assert exit_code == 0, f"Generation failed:\n{output}"
+
+        generated = self.generated_dir / "23_cdc_scd1_pk" / "cdc_scd1_pk_file.py"
+        assert generated.exists(), (
+            "cdc_scd1_pk_file.py should be generated under 23_cdc_scd1_pk/"
+        )
+
+        text = generated.read_text()
+        assert "dp.create_streaming_table(" in text
+        assert "dp.create_auto_cdc_flow(" in text
+        assert "stored_as_scd_type=1" in text
+        assert "PRIMARY KEY" in text
+        assert "__START_AT" not in text
+        assert "__END_AT" not in text

--- a/tests/test_config_validator_dlt_cdc.py
+++ b/tests/test_config_validator_dlt_cdc.py
@@ -49,6 +49,36 @@ class TestConfigValidatorDltCdc:
         assert not any("__START_AT" in str(e) for e in errors), errors
         assert not any("__END_AT" in str(e) for e in errors), errors
 
+    def test_cdc_scd1_inline_table_schema_primary_key_wiring(self):
+        """End-to-end wiring: a CDC SCD1 write target whose inline table_schema declares
+        a PRIMARY KEY (and, correctly, no __START_AT/__END_AT) validates cleanly. The
+        validity-column check applies to SCD2 only, so SCD1 can register a PRIMARY KEY."""
+        validator = ConfigValidator()
+        action = Action(
+            name="write_dim_customer_scd1",
+            type=ActionType.WRITE,
+            source="v_customer_bronze",
+            write_target={
+                "type": "streaming_table",
+                "catalog": "cat",
+                "schema": "silver",
+                "table": "dim_customer",
+                "mode": "cdc",
+                "table_schema": (
+                    "customer_sk STRING NOT NULL, customer_id BIGINT NOT NULL, "
+                    "c_name STRING, CONSTRAINT dim_customer_pk PRIMARY KEY (customer_sk)"
+                ),
+                "cdc_config": {
+                    "keys": ["customer_id"],
+                    "sequence_by": "last_modified_dt",
+                    "scd_type": 1,
+                },
+            },
+        )
+        errors = validator.validate_action(action, 1)
+        assert not any("__START_AT" in str(e) for e in errors), errors
+        assert not any("__END_AT" in str(e) for e in errors), errors
+
     def test_dlt_table_options_validation_comprehensive(self):
         validator = ConfigValidator()
 
@@ -531,7 +561,11 @@ class TestConfigValidatorDltCdc:
                 "schema": "test",
                 "table": "test",
                 "mode": "cdc",
-                "cdc_config": {"keys": ["id"], "sequence_by": "timestamp_col"},
+                "cdc_config": {
+                    "keys": ["id"],
+                    "sequence_by": "timestamp_col",
+                    "scd_type": 2,
+                },
                 "table_schema": "id INT, name STRING, __END_AT TIMESTAMP",  # Missing __START_AT
             },
         )
@@ -552,7 +586,11 @@ class TestConfigValidatorDltCdc:
                 "schema": "test",
                 "table": "test",
                 "mode": "cdc",
-                "cdc_config": {"keys": ["id"], "sequence_by": "timestamp_col"},
+                "cdc_config": {
+                    "keys": ["id"],
+                    "sequence_by": "timestamp_col",
+                    "scd_type": 2,
+                },
                 "table_schema": "id INT, name STRING, __START_AT TIMESTAMP",  # Missing __END_AT
             },
         )
@@ -573,7 +611,11 @@ class TestConfigValidatorDltCdc:
                 "schema": "test",
                 "table": "test",
                 "mode": "cdc",
-                "cdc_config": {"keys": ["id"], "sequence_by": "timestamp_col"},
+                "cdc_config": {
+                    "keys": ["id"],
+                    "sequence_by": "timestamp_col",
+                    "scd_type": 2,
+                },
                 "table_schema": "id INT, name STRING",  # Missing both __START_AT and __END_AT
             },
         )
@@ -599,7 +641,11 @@ class TestConfigValidatorDltCdc:
                 "schema": "test",
                 "table": "test",
                 "mode": "cdc",
-                "cdc_config": {"keys": ["id"], "sequence_by": "timestamp_col"},
+                "cdc_config": {
+                    "keys": ["id"],
+                    "sequence_by": "timestamp_col",
+                    "scd_type": 2,
+                },
                 "table_schema": "id INT, name STRING",  # Missing both __START_AT and __END_AT
             },
         )
@@ -625,7 +671,11 @@ class TestConfigValidatorDltCdc:
                 "schema": "test",
                 "table": "test",
                 "mode": "cdc",
-                "cdc_config": {"keys": ["id"], "sequence_by": "timestamp_col"},
+                "cdc_config": {
+                    "keys": ["id"],
+                    "sequence_by": "timestamp_col",
+                    "scd_type": 2,
+                },
                 "table_schema": "id INT, name STRING, __START_AT TIMESTAMP, __END_AT TIMESTAMP",
             },
         )
@@ -643,7 +693,11 @@ class TestConfigValidatorDltCdc:
                 "schema": "test",
                 "table": "test",
                 "mode": "cdc",
-                "cdc_config": {"keys": ["id"], "sequence_by": "timestamp_col"},
+                "cdc_config": {
+                    "keys": ["id"],
+                    "sequence_by": "timestamp_col",
+                    "scd_type": 2,
+                },
                 # No schema field - should NOT trigger schema validation
             },
         )

--- a/tests/test_dlt_cdc_validators_extended.py
+++ b/tests/test_dlt_cdc_validators_extended.py
@@ -703,11 +703,12 @@ class TestCdcSchemaValidatorDirect:
         assert errors == []
 
     def test_validate_schema_missing_start_at(self):
-        """Schema without __START_AT should produce error."""
+        """SCD2 schema without __START_AT should produce error."""
         action = self._make_action(
             write_target={
                 "type": "streaming_table",
                 "table_schema": "id INT, name STRING, __END_AT TIMESTAMP",
+                "cdc_config": {"scd_type": 2},
             }
         )
         errors = self.validator.validate(action, self.prefix)
@@ -715,11 +716,12 @@ class TestCdcSchemaValidatorDirect:
         assert not any("__END_AT" in e for e in errors)
 
     def test_validate_schema_missing_end_at(self):
-        """Schema without __END_AT should produce error."""
+        """SCD2 schema without __END_AT should produce error."""
         action = self._make_action(
             write_target={
                 "type": "streaming_table",
                 "table_schema": "id INT, name STRING, __START_AT TIMESTAMP",
+                "cdc_config": {"scd_type": 2},
             }
         )
         errors = self.validator.validate(action, self.prefix)
@@ -738,11 +740,12 @@ class TestCdcSchemaValidatorDirect:
         assert errors == []
 
     def test_validate_schema_missing_both_columns(self):
-        """Schema missing both __START_AT and __END_AT should produce two errors."""
+        """SCD2 schema missing both __START_AT and __END_AT should produce two errors."""
         action = self._make_action(
             write_target={
                 "type": "streaming_table",
                 "table_schema": "id INT, name STRING",
+                "cdc_config": {"scd_type": 2},
             }
         )
         errors = self.validator.validate(action, self.prefix)
@@ -762,11 +765,12 @@ class TestCdcSchemaValidatorDirect:
         assert errors == []
 
     def test_validate_table_schema_key_missing_columns(self):
-        """Schema via 'table_schema' key missing CDC columns should produce errors."""
+        """SCD2 schema via 'table_schema' key missing CDC columns should produce errors."""
         action = self._make_action(
             write_target={
                 "type": "streaming_table",
                 "table_schema": "id INT, name STRING",
+                "cdc_config": {"scd_type": 2},
             }
         )
         errors = self.validator.validate(action, self.prefix)


### PR DESCRIPTION
CdcSchemaValidator required `__START_AT`/`__END_AT` columns for every mode: cdc write target, including `scd_type: 1`. Those validity columns only exist on SCD Type 2 tables (the Lakeflow runtime rejects them on Type 1), so a Type 1 target could never satisfy both LHP and the runtime. Because `table_schema` is the only way to declare a `PRIMARY KEY` on a pipeline-managed table, this blocked SCD1 dimensions from registering a PK; keeping them out of the Unity Catalog ERD and unreferenceable by any `FOREIGN KEY`.

The fix gates the `__START_AT`/`__END_AT` presence check inside the validator on the effective SCD type (cdc_config.scd_type, default 1), mirroring what the generator emits (`stored_as_scd_type` in `streaming_table.py.j2`). The check now runs only for `scd_type == 2`; Type 1 targets validate cleanly. This complements the earlier #227 fix (file-based table_schema resolution), which is left unchanged.

Scope is limited to removing the false positive; no reverse-direction error is added for Type 1 targets that wrongly declare validity columns.

See issue for more info: #231