### PR TITLE
fix(uc-tagging): correct the failure-budget comment in the generated hook (#201 follow-up)

### DIFF
--- a/src/lhp/templates/uc_tagging/hook.py.j2
+++ b/src/lhp/templates/uc_tagging/hook.py.j2
@@ -293,9 +293,10 @@ def _apply(w, suppress_absent):
     return errors
 
 
-# A run raises at most twice — one combined RUNNING warning (snapshot + tag errors)
-# and one terminal warning — and the counter resets each update (the module re-imports
-# per run), so 3 leaves headroom without ever silently disabling tagging on a clean run.
+# The budget is uc_tagging.max_allowable_consecutive_failures. None (the default) means
+# no limit: a failing hook keeps raising on every update until the cause is fixed, and
+# tags are applied again on the next successful run. An integer lets SDP disable the
+# hook after that many consecutive failures.
 @dp.on_event_hook(max_allowable_consecutive_failures={{ max_allowable_consecutive_failures }})
 def uc_tagging_hook(event):
     """Tag managed tables/columns during the run, surfacing failures as warnings.

--- a/tests/e2e/fixtures/testing_project/generated_baseline/dev/uc_tagging_core/_uc_tagging_hook.py
+++ b/tests/e2e/fixtures/testing_project/generated_baseline/dev/uc_tagging_core/_uc_tagging_hook.py
@@ -295,9 +295,10 @@ def _apply(w, suppress_absent):
     return errors
 
 
-# A run raises at most twice — one combined RUNNING warning (snapshot + tag errors)
-# and one terminal warning — and the counter resets each update (the module re-imports
-# per run), so 3 leaves headroom without ever silently disabling tagging on a clean run.
+# The budget is uc_tagging.max_allowable_consecutive_failures. None (the default) means
+# no limit: a failing hook keeps raising on every update until the cause is fixed, and
+# tags are applied again on the next successful run. An integer lets SDP disable the
+# hook after that many consecutive failures.
 @dp.on_event_hook(max_allowable_consecutive_failures=3)
 def uc_tagging_hook(event):
     """Tag managed tables/columns during the run, surfacing failures as warnings.

--- a/tests/e2e/fixtures/testing_project/generated_baseline/dev/uc_tagging_mv/_uc_tagging_hook.py
+++ b/tests/e2e/fixtures/testing_project/generated_baseline/dev/uc_tagging_mv/_uc_tagging_hook.py
@@ -298,9 +298,10 @@ def _apply(w, suppress_absent):
     return errors
 
 
-# A run raises at most twice — one combined RUNNING warning (snapshot + tag errors)
-# and one terminal warning — and the counter resets each update (the module re-imports
-# per run), so 3 leaves headroom without ever silently disabling tagging on a clean run.
+# The budget is uc_tagging.max_allowable_consecutive_failures. None (the default) means
+# no limit: a failing hook keeps raising on every update until the cause is fixed, and
+# tags are applied again on the next successful run. An integer lets SDP disable the
+# hook after that many consecutive failures.
 @dp.on_event_hook(max_allowable_consecutive_failures=3)
 def uc_tagging_hook(event):
     """Tag managed tables/columns during the run, surfacing failures as warnings.


### PR DESCRIPTION
Closes the loop on #201, which PR #203 implemented (`uc_tagging.max_allowable_consecutive_failures`, default `null`).

## What was still wrong

Verification of #203 on this branch found every layer correct (parser, validation, model, template, JSON schema, docs, skill MDs, web form, CHANGELOG; 71 tests green) except one: the static comment the hook template renders above `@dp.on_event_hook(...)` still said *"so 3 leaves headroom without ever silently disabling tagging"*. It ships into every generated `_uc_tagging_hook.py` regardless of the configured value, and it restates exactly the assumption #201 reported as false.

## Change

- `src/lhp/templates/uc_tagging/hook.py.j2`: four-line comment rewritten to describe both renderings (`None` = never disabled, an integer = SDP disables the hook after that many consecutive failures). It deliberately no longer claims the counter "resets each update"; #201's own report contradicts that, and the claim is not verified against SDP.
- The two `uc_tagging_*` e2e baselines carry the identical comment lines (hand-edited, no formatter).

No code or behaviour change.

## Verification

- `tests/unit/test_uc_tagging_hook_generator.py` + `tests/unit/test_uc_tagging_config.py`: 63 passed.
- Full e2e suite (`LHP_NO_CACHE=1`, `-n 4`): 196 passed, proving only those two baselines moved.
- `ruff check src/` / `ruff format --check src/`: clean. Constitution gates (`scripts/check_baseline_gates.sh`): pass.

## Noted, not changed (owner decisions)

- `docs/reference/actions/write.rst:202-204` and `CHANGELOG.md:67-70` still carry the "counter resets each update" wording.
- `.claude/skills/lhp/references/` is 16 files behind `src/lhp/resources/skills/lhp/references/`; the `sync-claude-skill` pre-commit hook detects it but no CI workflow runs pre-commit.
- `uc_tagging` has no commented block in the `init`/`init_sample` `lhp.yaml.j2` templates and no section in `project-config.md`.