### PR TITLE
fix(init-sample): quote the _meta schema name in the data_prep notebook (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`lhp init --sample`: the `data_prep` task no longer fails with a `NameError`.**
+  The sample quickstart's data-prep notebook referenced a bare `_meta` where the
+  `_meta` schema *name* was meant, so the first task of the `lhp_sample_quickstart`
+  job aborted with `NameError: name '_meta' is not defined` before creating any
+  schema — taking the whole quickstart down. Regression in v0.9.1.
+
 - **SQL dependency extraction no longer invents edges from opaque `stream()`
   arguments.** sqlglot 28 began emitting a dedicated `exp.Stream` node above
   the wrapped table, which bypassed the opaqueness check: `stream('bronze.x')`

--- a/docs/_fixtures/sample_project/README.md
+++ b/docs/_fixtures/sample_project/README.md
@@ -25,9 +25,10 @@ job task is generated pipeline code.
   workspace.
 - **Serverless compute** enabled — the notebook task and all three pipelines
   run serverless.
-- A **catalog you can `CREATE` in**. The demo creates three schemas
-  (`sample_bronze`, `sample_silver`, `sample_gold`) and one volume
-  (`<your_catalog>.sample_bronze.landing`) inside it.
+- A **catalog you can `CREATE` in**. The demo creates four schemas
+  (`sample_bronze`, `sample_silver`, `sample_gold`, `_meta`) and two volumes
+  (`<your_catalog>.sample_bronze.landing` and
+  `<your_catalog>._meta.checkpoints`) inside it.
 - The **Databricks CLI** installed and authenticated
   (`databricks auth login --host https://<your-workspace>`).
 - `lhp` installed (it generated this project).

--- a/docs/_fixtures/sample_project/notebooks/data_prep.py
+++ b/docs/_fixtures/sample_project/notebooks/data_prep.py
@@ -103,7 +103,7 @@ def month_window(n):
 
 # COMMAND ----------
 
-for schema in (bronze_schema, silver_schema, gold_schema, _meta):
+for schema in (bronze_schema, silver_schema, gold_schema, "_meta"):
     spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{catalog}`.`{schema}`")
 spark.sql(f"CREATE VOLUME IF NOT EXISTS `{catalog}`.`{bronze_schema}`.landing")
 spark.sql(f"CREATE VOLUME IF NOT EXISTS `{catalog}`.`_meta`.checkpoints")

--- a/docs/get-started/02-configure-the-project.rst
+++ b/docs/get-started/02-configure-the-project.rst
@@ -51,8 +51,9 @@ environment-specific values live:
 Set the two highlighted values:
 
 1. :guilabel:`edit` ``catalog`` — a Unity Catalog catalog you can ``CREATE`` in.
-   The demo makes three schemas (``sample_bronze``, ``sample_silver``,
-   ``sample_gold``) and a landing volume inside it.
+   The demo makes four schemas (``sample_bronze``, ``sample_silver``,
+   ``sample_gold``, ``_meta``) and two volumes (the landing volume and
+   ``_meta.checkpoints``) inside it.
 2. :guilabel:`edit` ``landing_volume`` — keep it in sync with the catalog above:
    ``/Volumes/<your_catalog>/sample_bronze/landing``.
 

--- a/src/lhp/templates/init_sample/README.md.j2
+++ b/src/lhp/templates/init_sample/README.md.j2
@@ -25,9 +25,10 @@ job task is generated pipeline code.
   workspace.
 - **Serverless compute** enabled — the notebook task and all three pipelines
   run serverless.
-- A **catalog you can `CREATE` in**. The demo creates three schemas
-  (`sample_bronze`, `sample_silver`, `sample_gold`) and one volume
-  (`<your_catalog>.sample_bronze.landing`) inside it.
+- A **catalog you can `CREATE` in**. The demo creates four schemas
+  (`sample_bronze`, `sample_silver`, `sample_gold`, `_meta`) and two volumes
+  (`<your_catalog>.sample_bronze.landing` and
+  `<your_catalog>._meta.checkpoints`) inside it.
 - The **Databricks CLI** installed and authenticated
   (`databricks auth login --host https://<your-workspace>`).
 - `lhp` installed (it generated this project).

--- a/src/lhp/templates/init_sample/notebooks/data_prep.py
+++ b/src/lhp/templates/init_sample/notebooks/data_prep.py
@@ -103,7 +103,7 @@ def month_window(n):
 
 # COMMAND ----------
 
-for schema in (bronze_schema, silver_schema, gold_schema, _meta):
+for schema in (bronze_schema, silver_schema, gold_schema, "_meta"):
     spark.sql(f"CREATE SCHEMA IF NOT EXISTS `{catalog}`.`{schema}`")
 spark.sql(f"CREATE VOLUME IF NOT EXISTS `{catalog}`.`{bronze_schema}`.landing")
 spark.sql(f"CREATE VOLUME IF NOT EXISTS `{catalog}`.`_meta`.checkpoints")

--- a/tests/unit/test_init_sample_notebook_static.py
+++ b/tests/unit/test_init_sample_notebook_static.py
@@ -1,0 +1,93 @@
+"""Static soundness of the packaged ``--sample`` data-prep notebook (issue #232).
+
+``src/lhp/templates/init_sample/notebooks/data_prep.py`` is Databricks notebook
+source that ships verbatim in the wheel and is copied byte-for-byte into every
+``lhp init --sample`` scaffold. Because it references the notebook-injected
+``spark`` / ``dbutils`` globals, its whole tree is excluded from ruff, mypy and
+vulture (``pyproject.toml``: ``[tool.ruff] extend-exclude``,
+``[tool.mypy] exclude``, ``[tool.vulture] exclude``) — so no linter ever sees
+it, and a plain undefined-name typo reaches users as a job failure on the very
+first task of the quickstart.
+
+These tests are the gate that was missing. They use :mod:`symtable` rather than
+importing the module, so they need neither Spark nor Databricks: every name read
+at *module* scope must also be bound at module scope, once the runtime-injected
+globals are allowed for.
+
+Issue #232: ``for schema in (bronze_schema, silver_schema, gold_schema, _meta)``
+read a bare ``_meta`` that was never assigned (the sibling statements use the
+quoted literal). Databricks runs every cell in one shared global namespace, so
+the cell raised ``NameError: name '_meta' is not defined`` and the ``data_prep``
+task of ``lhp_sample_quickstart`` failed before creating any schema.
+"""
+
+import builtins
+import symtable
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+#: The packaged template and the ``docs/`` fixture copy of it. They must stay
+#: byte-identical, so both are checked.
+NOTEBOOK_COPIES = [
+    REPO / "src/lhp/templates/init_sample/notebooks/data_prep.py",
+    REPO / "docs/_fixtures/sample_project/notebooks/data_prep.py",
+]
+
+#: Globals the Databricks notebook runtime injects into the user namespace.
+#: Anything outside this set (and builtins) must be bound in the file itself.
+DATABRICKS_INJECTED_GLOBALS = frozenset(
+    {
+        "spark",
+        "dbutils",
+        "sc",
+        "sqlContext",
+        "display",
+        "displayHTML",
+        "getArgument",
+        "dlt",
+    }
+)
+
+
+def _unbound_module_scope_names(path: Path) -> list[str]:
+    """Names read at module scope of ``path`` that are never bound there."""
+    table = symtable.symtable(path.read_text(encoding="utf-8"), str(path), "exec")
+    builtin_names = frozenset(dir(builtins))
+    return sorted(
+        sym.get_name()
+        for sym in table.get_symbols()
+        if sym.is_referenced()
+        and not sym.is_assigned()
+        and not sym.is_imported()
+        and sym.get_name() not in builtin_names
+        and sym.get_name() not in DATABRICKS_INJECTED_GLOBALS
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("notebook", NOTEBOOK_COPIES, ids=lambda p: p.parts[-4])
+def test_data_prep_notebook_binds_every_module_scope_name(notebook: Path) -> None:
+    """Regression for issue #232 — no undefined names at notebook module scope."""
+    unbound = _unbound_module_scope_names(notebook)
+    assert unbound == [], (
+        f"{notebook.relative_to(REPO)} reads name(s) {unbound} at module scope "
+        "that are never bound there. Databricks executes notebook cells in one "
+        "shared global namespace, so this raises NameError at runtime and fails "
+        "the data_prep task of the sample quickstart job (issue #232). A schema "
+        "or table name needs quoting; a real value needs an assignment (or a "
+        "dbutils widget)."
+    )
+
+
+@pytest.mark.unit
+def test_docs_fixture_notebook_matches_packaged_template() -> None:
+    """The ``docs/`` fixture copy must mirror the packaged template byte-for-byte."""
+    packaged, fixture = NOTEBOOK_COPIES
+    assert fixture.read_bytes() == packaged.read_bytes(), (
+        f"{fixture.relative_to(REPO)} has drifted from "
+        f"{packaged.relative_to(REPO)}. The fixture is the copy that "
+        "docs/get-started/ describes; keep both in sync in the same commit."
+    )


### PR DESCRIPTION
Fixes #232.

## Root cause

`src/lhp/templates/init_sample/notebooks/data_prep.py:106` iterates over `(bronze_schema, silver_schema, gold_schema, _meta)` with a bare `_meta` that is never assigned anywhere; lines 109 and 111 use the quoted literal `"_meta"`. The notebook is package data copied byte-for-byte into every `lhp init --sample` scaffold, and Databricks executes all cells in one shared namespace, so the tuple evaluation raises `NameError: name '_meta' is not defined` before any schema is created. Deterministic for every user, on any compute. Introduced by 3cd010d9 (in `v0.9.1` only); unchanged on this branch until now.

Why no gate caught it: the whole `init_sample` tree is excluded from ruff, mypy and vulture (`pyproject.toml` `extend-exclude`, `[tool.mypy] exclude`, `[tool.vulture] exclude`) because it references the notebook-injected `spark`/`dbutils` globals.

## Change

- `_meta` → `"_meta"` in both tracked copies (`src/lhp/templates/init_sample/notebooks/data_prep.py`, `docs/_fixtures/sample_project/notebooks/data_prep.py`); the copies stay byte-identical.
- Prose drift from the same original commit corrected in three places to say four schemas and two volumes (`init_sample/README.md.j2`, the docs fixture README, `docs/get-started/02-configure-the-project.rst`).
- New `tests/unit/test_init_sample_notebook_static.py`: a `symtable`-based check (no Spark) that every module-scope name read in the packaged notebook is bound, allowing for the Databricks-injected globals, plus a guard that the two copies stay identical. Red before the fix, green after.
- CHANGELOG `### Fixed` entry under `[Unreleased]`.

The reporter's proposed fix (add the meta schema as a notebook variable/parameter) was not taken: `_meta` is not user-supplied, it is hard-coded in `lhp.yaml.j2` (`event_log.schema`, `monitoring.checkpoint_path`), so a widget would add a second place to keep in sync.

## Verification

- New static test: 3 passed. `tests/e2e/test_init_sample_e2e.py`: 3 passed (existence-only assertions; no e2e file changed).
- `tests/unit`: 439 passed. `ruff check` / `ruff format --check` on `src/ tests/`: clean. Constitution gates: pass.
- Freshly scaffolded notebook runs to completion under stubbed `spark`/`dbutils`.
- No `literalinclude` targets the notebook or READMEs; the one ranged include (`sample_job.yml` lines 15-38) is untouched.

## Noted, not changed (owner decisions)

- The notebook declares a `bronze_schema` widget (default `sample_bronze`) but `sample_job.yml` passes only `catalog` and `round`; a user who changes `bronze_schema` in `substitutions/dev.yaml` gets pipelines and seed data pointing at different schemas.
- `.claude/settings.json` still runs the deleted `scripts/check_docs.py` on every `.rst` edit, and its per-edit ruff hook would reformat packaged notebook source when editing from a worktree; the agent had to edit via shell to avoid both.