### PR TITLE
fix(generators): default omitted python parameters to {} instead of null (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   job aborted with `NameError: name '_meta' is not defined` before creating any
   schema — taking the whole quickstart down. Regression in v0.9.1.
 
+- **Python load/transform actions that omit `parameters` now receive `{}`
+  instead of the unbound name `null`.** A `transform_type: python` action with
+  no `parameters:` block (or a bare `parameters:` key, which YAML reads as
+  null) generated `parameters = null`, so the deployed pipeline imported
+  cleanly and then failed with `NameError: name 'null' is not defined` the
+  first time the view was evaluated. The same applied to a `source.type:
+  python` load with an explicit `parameters:` null. Both now emit
+  `parameters = {}`, the default the reference documentation always described.
 - **SQL dependency extraction no longer invents edges from opaque `stream()`
   arguments.** sqlglot 28 began emitting a dedicated `exp.Stream` node above
   the wrapped table, which bypassed the opaqueness check: `stream('bronze.x')`

--- a/src/lhp/generators/load/python.py
+++ b/src/lhp/generators/load/python.py
@@ -44,7 +44,9 @@ class PythonLoadGenerator(BaseActionGenerator):
 
         module_path = source_config.get("module_path")
         function_name = source_config.get("function_name", "get_df")
-        parameters = source_config.get("parameters", {})
+        # Coalesce: a present-but-null `parameters:` key yields None, which the
+        # template would emit as the unbound name `null`.
+        parameters = source_config.get("parameters") or {}
 
         if not module_path:
             raise ErrorFactory.missing_required_field(

--- a/src/lhp/generators/transform/python.py
+++ b/src/lhp/generators/transform/python.py
@@ -22,7 +22,10 @@ class PythonTransformGenerator(BaseActionGenerator):
         )
         module_path = getattr(action, "module_path", None)
         function_name = getattr(action, "function_name", None)
-        parameters = getattr(action, "parameters", {})
+        # Coalesce, don't rely on getattr's default: the model field exists with
+        # value None when YAML omits (or nulls) it, and the template renders
+        # `parameters` unconditionally — None would emit the unbound name `null`.
+        parameters = getattr(action, "parameters", None) or {}
 
         if "substitution_manager" in context:
             substitution_mgr = context["substitution_manager"]

--- a/tests/generators/load/test_python_load_parameters_default.py
+++ b/tests/generators/load/test_python_load_parameters_default.py
@@ -1,0 +1,94 @@
+"""Regression tests for issue #189 — python load ``source.parameters`` default.
+
+The sibling of the python-transform defect. ``source_config.get("parameters")``
+reads a plain YAML dict, so an *absent* key already yielded ``{}``; only a
+present-but-null ``parameters:`` leaked ``None`` into
+``parameters = {{ parameters | tojson }}`` and emitted the unbound name
+``null``. The documented default is ``{}``
+(``docs/reference/actions/load.rst``).
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from lhp.generators.load.python import PythonLoadGenerator
+from lhp.models import Action, ActionType, FlowGroup
+
+LOADER_MODULE_SOURCE = """
+def load_data(spark, parameters):
+    return None
+"""
+
+
+def _generate(tmp_path: Path, source: dict) -> str:
+    """Render the python-load action, writing its module into ``tmp_path``."""
+    loaders = tmp_path / "loaders"
+    loaders.mkdir(parents=True, exist_ok=True)
+    (loaders / "my_loader.py").write_text(LOADER_MODULE_SOURCE)
+
+    action = Action(
+        name="load_custom_data",
+        type=ActionType.LOAD,
+        source=source,
+        target="v_custom_data",
+    )
+    return PythonLoadGenerator().generate(
+        action,
+        {
+            "output_dir": tmp_path / "generated",
+            "spec_dir": tmp_path,
+            "flowgroup": FlowGroup(
+                pipeline="test_pipeline", flowgroup="test_flowgroup", actions=[]
+            ),
+        },
+    )
+
+
+def _source(**overrides) -> dict:
+    source = {
+        "type": "python",
+        "module_path": "loaders/my_loader.py",
+        "function_name": "load_data",
+    }
+    source.update(overrides)
+    return source
+
+
+def _parameters_assignments(code: str) -> list:
+    """Every ``parameters = ...`` right-hand side in the generated code."""
+    return [
+        line.split("=", 1)[1].strip()
+        for line in code.splitlines()
+        if line.strip().startswith("parameters =")
+    ]
+
+
+@pytest.mark.unit
+def test_yaml_null_parameters_render_empty_dict():
+    """A bare ``parameters:`` key (YAML null) emits ``{}``, never ``null``."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code = _generate(Path(tmpdir), _source(parameters=None))
+
+    assert _parameters_assignments(code) == ["{}"]
+    assert "null" not in code
+
+
+@pytest.mark.unit
+def test_omitted_parameters_render_empty_dict():
+    """An absent key was already correct; pin it so it stays that way."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code = _generate(Path(tmpdir), _source())
+
+    assert _parameters_assignments(code) == ["{}"]
+    assert "null" not in code
+
+
+@pytest.mark.unit
+def test_declared_parameters_are_passed_through_unchanged():
+    """The coalesce must not disturb a populated dict."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code = _generate(Path(tmpdir), _source(parameters={"region": "us"}))
+
+    assert _parameters_assignments(code) == ['{"region": "us"}']

--- a/tests/generators/transform/test_python_transform_parameters_default.py
+++ b/tests/generators/transform/test_python_transform_parameters_default.py
@@ -1,0 +1,90 @@
+"""Regression tests for issue #189 — python transform ``parameters`` default.
+
+``Action.parameters`` is ``Optional`` and defaults to ``None``, so the
+attribute exists with value ``None`` whenever YAML omits it. The template
+renders ``parameters = {{ parameters | tojson }}`` unconditionally and
+``tojson`` is bound to :func:`json.dumps`, so a ``None`` used to emit
+``parameters = null`` — an unbound name that raises ``NameError`` the first
+time Lakeflow evaluates the view. The documented default is ``{}``
+(``docs/reference/actions/transform.rst``), which is also what the dependency
+analyser already assumes (``core/dependencies/_binding_rules.py``).
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from lhp.generators.transform import PythonTransformGenerator
+from lhp.models import Action, ActionType, FlowGroup, TransformType
+
+TRANSFORM_MODULE_SOURCE = """
+def enrich_customers(df, spark, parameters):
+    return df
+"""
+
+
+def _generate(tmp_path: Path, **action_fields) -> str:
+    """Render the python-transform action, writing its module into ``tmp_path``."""
+    transformations = tmp_path / "transformations"
+    transformations.mkdir(parents=True, exist_ok=True)
+    (transformations / "enrich_customers.py").write_text(TRANSFORM_MODULE_SOURCE)
+
+    action = Action(
+        name="enrich_customers",
+        type=ActionType.TRANSFORM,
+        transform_type=TransformType.PYTHON,
+        source="v_customers_validated",
+        target="v_customers_enriched",
+        module_path="transformations/enrich_customers.py",
+        function_name="enrich_customers",
+        **action_fields,
+    )
+    return PythonTransformGenerator().generate(
+        action,
+        {
+            "output_dir": tmp_path / "generated",
+            "spec_dir": tmp_path,
+            "flowgroup": FlowGroup(
+                pipeline="test_pipeline", flowgroup="test_flowgroup", actions=[]
+            ),
+        },
+    )
+
+
+def _parameters_assignments(code: str) -> list:
+    """Every ``parameters = ...`` right-hand side in the generated code."""
+    return [
+        line.split("=", 1)[1].strip()
+        for line in code.splitlines()
+        if line.strip().startswith("parameters =")
+    ]
+
+
+@pytest.mark.unit
+def test_omitted_parameters_render_empty_dict():
+    """No ``parameters:`` in YAML still emits a usable dict, never ``null``."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code = _generate(Path(tmpdir))
+
+    assert _parameters_assignments(code) == ["{}"]
+    assert "null" not in code
+
+
+@pytest.mark.unit
+def test_yaml_null_parameters_render_empty_dict():
+    """A bare ``parameters:`` key (YAML null) behaves like an omitted one."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code = _generate(Path(tmpdir), parameters=None)
+
+    assert _parameters_assignments(code) == ["{}"]
+    assert "null" not in code
+
+
+@pytest.mark.unit
+def test_declared_parameters_are_passed_through_unchanged():
+    """The coalesce must not disturb a populated dict."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        code = _generate(Path(tmpdir), parameters={"enrichment_type": "full"})
+
+    assert _parameters_assignments(code) == ['{"enrichment_type": "full"}']

--- a/tests/test_python_transform_substitution.py
+++ b/tests/test_python_transform_substitution.py
@@ -199,7 +199,7 @@ def simple_transform(df, spark, parameters):
         code = generator.generate(action, context)
 
         assert "simple_transform" in code
-        assert "parameters =" in code  # May be {} or null depending on how it's handled
+        assert "parameters = {}" in code
 
         transform_file.unlink()
 


### PR DESCRIPTION
Fixes #189.

## Root cause

| Step | Evidence |
|---|---|
| Model | `src/lhp/models/_action.py:107` — `parameters: Optional[Dict[str, Any]] = None`; the attribute always exists |
| Generator | `src/lhp/generators/transform/python.py:25` — `getattr(action, "parameters", {})` returns `None` (the default only fires for a missing attribute) |
| Filter | `src/lhp/core/codegen/template_renderer.py:59` — `tojson` is `json.dumps`, so `None` → `null` |
| Template | `src/lhp/templates/transform/python.py.j2:15,24` — `parameters = {{ parameters | tojson }}` → `parameters = null` |

`null` is a valid Python name, so the module compiles and imports; it fails with `NameError: name 'null' is not defined` the first time Lakeflow evaluates the view. Validation waves `None` through (`core/validators/action/transform.py:122`). `src/lhp/generators/load/python.py:47` has the narrower form (explicit `parameters:` YAML null). The docs and skill reference already state the default as `{}`; the dependency-analysis layer (`core/dependencies/_binding_rules.py:59`) already coalesces. Codegen was the only layer leaking `None`.

## Change

- Two one-line coalesces (`... or {}`) in the transform and load python generators, with a short WHY comment each.
- New unit tests: `tests/generators/transform/test_python_transform_parameters_default.py` (omitted, YAML-null, populated pass-through) and `tests/generators/load/test_python_load_parameters_default.py` (YAML-null, absent key, pass-through).
- `tests/test_python_transform_substitution.py:202` tightened from "may be `{}` or `null`" to `parameters = {}`.
- CHANGELOG `### Fixed` entry under `[Unreleased]`.

No e2e file changed. Byte-neutral for every fixture: repo-wide grep finds no `parameters = null` in any baseline, and `X or {}` is the identity on every populated dict.

## Verification

- New tests: 6 passed. Generator/substitution/dependency suites: 956 passed.
- Full e2e (`LHP_NO_CACHE=1`, `-n 4`): 196 passed.
- `ruff check` / `ruff format --check` on `src/ tests/`: clean. Constitution gates: pass.

## Deliberately out of scope (owner decisions)

- **JSON-vs-Python literals.** Because `tojson` is `json.dumps`, `parameters: {enabled: true}` emits `{"enabled": true}` and fails the same way at runtime. Closing that class means emitting Python literals at every `tojson` site and regenerating all e2e baselines. Worth its own issue.
- **Sibling `options` sites** with the identical `.get(key, {})` shape: `write/sinks/custom_sink.py:71` (would emit `options=null`) and `write/sinks/delta_sink.py:16` (`TypeError` at `len(options)`), both reachable only via an explicit YAML null.
- **e2e regression.** An action added to `09_test_python/sample_python_func_flow.yaml` would also move the wheel content hash embedded in `resources_baseline_wheel/lhp/sample_python_func_pipeline.pipeline.yml`; that fixture addition was built, verified, and reverted pending approval to touch e2e baselines.