### PR TITLE
docs(uc-tagging): describe hook disabling as Databricks documents it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consecutive failures allowed and the hook is never disabled. Projects that
   regenerate will see `@dp.on_event_hook(max_allowable_consecutive_failures=None)` in
   `_uc_tagging_hook.py`. In practice a run raises at most twice (one combined `RUNNING`
-  warning, one terminal warning) and the counter resets each update because the module
-  re-imports per run, so a clean run never accumulated consecutive failures under the
-  old budget either. Set `uc_tagging.max_allowable_consecutive_failures: 3` to restore
+  warning, one terminal warning); under the old budget a hook that hit the limit was
+  disabled and, per Databricks, did not process new events until the pipeline was
+  restarted (#201). Set `uc_tagging.max_allowable_consecutive_failures: 3` to restore
   the previous behavior.
 
 ## [0.9.1] — 2026-06-10

--- a/docs/reference/actions/write.rst
+++ b/docs/reference/actions/write.rst
@@ -200,10 +200,11 @@ never fail the update (event hooks cannot). Key-only tags use ``""``, ``~``, or
 an omitted value.
 
 A run raises at most twice — one combined ``RUNNING`` warning and one terminal
-warning — and the counter resets each update because the module re-imports per
-run, so a clean run never accumulates consecutive failures. Set
-``max_allowable_consecutive_failures`` to have SDP disable the hook after a given
-number of consecutive failures; by default there is no limit.
+warning. By default there is no failure limit: a hook that keeps failing keeps
+raising until the cause is fixed, and tags are applied again on the next
+successful run. Set ``max_allowable_consecutive_failures`` to have SDP disable
+the hook after that many consecutive failures; Databricks documents that a
+disabled hook does not process new events until the pipeline is restarted.
 
 Existing tag state is read once at module import with a single
 ``system.information_schema`` query (``table_tags`` ``UNION ALL``


### PR DESCRIPTION
Docs-only follow-up to #203 / #244 (issue #201).

`docs/reference/actions/write.rst` (UC tagging section) and the `[0.9.2]` CHANGELOG entry both asserted that the event hook's consecutive-failure counter "resets each update because the module re-imports per run". That is an inference, not documented behaviour: the Databricks event-hooks page says only that `max_allowable_consecutive_failures` defaults to `None` (no limit) and that "if an event hook is disabled, it does not process new events until the pipeline is restarted". Issue #201's report (hook stayed disabled across re-runs) contradicts the reset claim.

Both passages now state the documented behaviour and what the `None` default means operationally (a failing hook keeps raising until fixed; tags are applied on the next successful run). The skill MDs never carried the claim, so no parity edit. No code, test, or e2e change.