### PR TITLE
fix(codegen): keep parent-module imports alongside a submodule wildcard (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first time the view was evaluated. The same applied to a `source.type:
   python` load with an explicit `parameters:` null. Both now emit
   `parameters = {}`, the default the reference documentation always described.
+
+- **`--include-tests` no longer drops `from pyspark.sql import functions as F`.**
+  When a flowgroup contained any `type: test` action, the import resolver treated
+  the test generators' `from pyspark.sql.functions import *` as superseding the
+  parent `pyspark.sql` import — but a wildcard never binds the name `F`, so the
+  generated module raised `NameError` on its first `F.` reference as soon as the
+  flow was evaluated. Any generator that emits `F.` was a trigger, not just
+  `transform_type: schema`: `operational_metadata` columns
+  (`F.current_timestamp()`) alone were enough, as were custom sinks. The
+  exclusion also applied to the whole `pyspark.sql` module group, so sibling
+  imports such as `from pyspark.sql import DataFrame` (materialized-view writes)
+  were dropped with it. Parent-module imports are now always kept; a wildcard
+  still supersedes specific-name imports from that same module. Both `lhp
+  validate` and `lhp generate` reported success, so the failure only surfaced at
+  pipeline start-up.
 - **SQL dependency extraction no longer invents edges from opaque `stream()`
   arguments.** sqlglot 28 began emitting a dedicated `exp.Stream` node above
   the wrapped table, which bypassed the opaqueness check: `stream('bronze.x')`

--- a/src/lhp/core/codegen/imports/resolver.py
+++ b/src/lhp/core/codegen/imports/resolver.py
@@ -1,87 +1,41 @@
 """Module-level conflict-resolution helpers for the import sub-package.
 
 Pure functions called from :class:`lhp.core.codegen.imports.manager.ImportManager`.
-The two rules implemented here:
+One rule survives here:
 
-1. Wildcard imports take precedence over specific imports from the same module.
-2. Submodule wildcard imports take precedence over parent-module-as-alias
-   imports (e.g. ``from pyspark.sql.functions import *`` beats
-   ``from pyspark.sql import functions as F``).
+1. Within a single module, a wildcard import supersedes that module's
+   specific-name imports (``from x import *`` beats ``from x import a, b``).
+   Sound because the wildcard binds every name the specific import bound.
+
+A second rule — a submodule wildcard superseding a parent-module import, e.g.
+``from pyspark.sql.functions import *`` beating ``from pyspark.sql import
+functions as F`` — was removed (issue #217). The two statements are not
+substitutes: a submodule wildcard binds *none* of the names a parent import
+binds. ``as F`` binds ``F``, the unaliased form binds ``functions``, and the
+wildcard binds only the individual function names. Dropping the parent emitted
+modules that raised ``NameError`` on the first ``F.col(...)`` — reachable from
+any flowgroup pairing an ``F.``-emitting generator with a ``type: test``
+action, since test generators contribute the wildcard. The old code also
+excluded the parent's whole *module group*, taking unrelated siblings such as
+``from pyspark.sql import DataFrame`` with it. Parent-module imports are now
+always kept.
 """
 
 from __future__ import annotations
 
 import logging
-import re
-from typing import Dict, List, Set
+from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
-
-
-def _is_parent_importing_child_as_alias(import_stmt: str, child_name: str) -> bool:
-    """Return True if ``import_stmt`` imports ``child_name`` (optionally aliased).
-
-    Examples:
-        ``"from pyspark.sql import functions as F"`` with child=``"functions"`` -> True
-        ``"from pyspark.sql import functions"`` with child=``"functions"`` -> True
-    """
-    pattern = rf"from\s+[^\s]+\s+import\s+.*\b{re.escape(child_name)}\b(?:\s+as\s+\w+)?"
-    return bool(re.search(pattern, import_stmt))
-
-
-def detect_submodule_conflicts(
-    module_groups: Dict[str, List[str]],
-    wildcard_modules: Set[str],
-    parent_child_conflicts: Dict[str, Dict[str, str]],
-) -> None:
-    """Populate ``parent_child_conflicts`` with parent/child wildcard collisions.
-
-    For each wildcard module, checks whether any other module is its prefix
-    and that prefix's import statement binds the child segment as an alias.
-    When both are true, records the conflict so the caller can drop the parent
-    import in favour of the child wildcard.
-
-    Mutates ``parent_child_conflicts`` in place.
-    """
-    for wildcard_module in wildcard_modules:
-        wildcard_parts = wildcard_module.split(".")
-
-        for other_module in module_groups:
-            if other_module == wildcard_module:
-                continue
-
-            other_parts = other_module.split(".")
-
-            if (
-                len(wildcard_parts) > len(other_parts)
-                and wildcard_parts[: len(other_parts)] == other_parts
-            ):
-                parent_imports = module_groups[other_module]
-                child_module_name = wildcard_parts[len(other_parts)]
-
-                for parent_import in parent_imports:
-                    if _is_parent_importing_child_as_alias(
-                        parent_import, child_module_name
-                    ):
-                        parent_child_conflicts[wildcard_module] = {
-                            "parent_module": other_module,
-                            "parent_import": parent_import,
-                            "child_alias": child_module_name,
-                        }
-                        logger.debug(
-                            f"Detected submodule conflict: {wildcard_module} "
-                            f"vs {parent_import}"
-                        )
-                        break
 
 
 def resolve_conflicts(
     imports: Set[str],
     *,
-    extract_module_name,
-    is_wildcard_import,
+    extract_module_name: Callable[[str], Optional[str]],
+    is_wildcard_import: Callable[[str], bool],
 ) -> Set[str]:
-    """Resolve import conflicts using hardcoded wildcard-precedence rules.
+    """Resolve same-module wildcard-vs-specific-name import conflicts.
 
     Args:
         imports: All collected import statements (deduplicated set).
@@ -92,16 +46,15 @@ def resolve_conflicts(
             ``from X import *`` form.
 
     Returns:
-        The resolved set of imports with wildcards replacing competing
-        specific imports, and parent-module-as-alias lines dropped when a
-        child wildcard supersedes them.
+        The resolved set of imports, with a module's wildcard replacing that
+        same module's specific-name imports. Imports from every other module
+        are kept, including from a parent module of a wildcard's module.
     """
     if not imports:
         return set()
 
     module_groups: Dict[str, List[str]] = {}
     wildcard_modules: Set[str] = set()
-    parent_child_conflicts: Dict[str, Dict[str, str]] = {}
 
     for imp in imports:
         module = extract_module_name(imp)
@@ -110,27 +63,20 @@ def resolve_conflicts(
             if is_wildcard_import(imp):
                 wildcard_modules.add(module)
 
-    detect_submodule_conflicts(module_groups, wildcard_modules, parent_child_conflicts)
-
     resolved: Set[str] = set()
-    excluded_modules: Set[str] = set()
 
-    # First pass: parent-module exclusions driven by child wildcard wins.
-    for child_module, parent_info in parent_child_conflicts.items():
-        if child_module in wildcard_modules:
-            excluded_modules.add(parent_info["parent_module"])
-            logger.debug(
-                f"Submodule conflict: {child_module} wildcard excludes "
-                f"{parent_info['parent_module']} imports"
-            )
-
-    # Second pass: per-module wildcard-vs-specific resolution.
     for module, module_imports in module_groups.items():
-        if module in excluded_modules:
-            continue
-
         if module in wildcard_modules:
+            # Caveat: an *aliased* specific name from the same module
+            # (``from x import col as c`` alongside ``from x import *``) loses
+            # the ``c`` binding here. Unreachable — no LHP generator emits one.
             wildcards = [imp for imp in module_imports if is_wildcard_import(imp)]
+            superseded = len(module_imports) - len(wildcards)
+            if superseded:
+                logger.debug(
+                    f"Wildcard import for '{module}' supersedes "
+                    f"{superseded} specific import(s)"
+                )
             resolved.update(wildcards)
         else:
             resolved.update(module_imports)

--- a/tests/core/codegen/imports/test_resolver_alias_binding.py
+++ b/tests/core/codegen/imports/test_resolver_alias_binding.py
@@ -1,0 +1,121 @@
+"""Regression guard for GitHub issue #217 — resolver must not drop bindings a wildcard cannot supply.
+
+``resolver.py`` once carried a rule #2 ("submodule wildcard imports take
+precedence over parent-module-as-alias imports"). It was unsound: ``from
+pyspark.sql.functions import *`` never binds the name ``F``, so dropping ``from
+pyspark.sql import functions as F`` in its favour produced a module whose
+``F.`` references were unbound — a ``NameError`` raised when SDP evaluated the
+flow, at pipeline start-up. The rule has been removed; these tests guard
+against its return.
+
+The trigger was ``lhp generate --include-tests``: every test-action generator
+contributes the wildcard (``BaseTestActionGenerator``) while any
+``F.``-emitting generator in the same flowgroup contributes the alias
+(``SchemaTransformGenerator``, ``BaseSinkGenerator``, and operational
+metadata's ``F.current_timestamp()``).
+"""
+
+import ast
+
+import pytest
+
+from lhp.core.codegen.imports import ImportManager
+
+pytestmark = pytest.mark.unit
+
+
+def _resolve(*imports: str) -> list[str]:
+    manager = ImportManager()
+    for statement in imports:
+        manager.add_import(statement)
+    return manager.get_consolidated_imports()
+
+
+def _bound_names(import_block: list[str]) -> set[str]:
+    """Local names an import block actually binds, per Python semantics."""
+    bound: set[str] = set()
+    for statement in import_block:
+        for node in ast.walk(ast.parse(statement)):
+            if isinstance(node, ast.ImportFrom):
+                bound |= {a.asname or a.name for a in node.names if a.name != "*"}
+            elif isinstance(node, ast.Import):
+                bound |= {a.asname or a.name.split(".")[0] for a in node.names}
+    return bound
+
+
+class TestAliasedParentSurvivesSubmoduleWildcard:
+    """An aliased parent import binds a name the child wildcard cannot supply."""
+
+    def test_alias_and_wildcard_both_kept(self):
+        resolved = _resolve(
+            "from pyspark.sql import functions as F",
+            "from pyspark.sql.functions import *",
+        )
+
+        assert "from pyspark.sql.functions import *" in resolved
+        assert "from pyspark.sql import functions as F" in resolved
+        assert "F" in _bound_names(resolved)
+
+    def test_issue_217_flowgroup_import_set_binds_F(self):
+        """The exact import set a schema transform + uniqueness test produces."""
+        resolved = _resolve(
+            # from generators/test/_base.py
+            "from pyspark import pipelines as dp",
+            "from pyspark.sql.functions import *",
+            # from generators/transform/schema.py
+            "from pyspark.sql import functions as F",
+            "from pyspark.sql.types import StructType",
+        )
+
+        assert "F" in _bound_names(resolved), (
+            "generated module references F.col(...) but no import binds 'F'"
+        )
+
+    def test_sibling_parent_imports_are_not_collateral_damage(self):
+        """Unrelated imports from the parent module must survive too.
+
+        The removed rule excluded the whole ``pyspark.sql`` module *group*, so
+        ``DataFrame`` (added by ``MaterializedViewGenerator``) disappeared as
+        well whenever the alias conflict was recorded.
+        """
+        resolved = _resolve(
+            "from pyspark.sql import DataFrame",
+            "from pyspark.sql import functions as F",
+            "from pyspark.sql.functions import *",
+        )
+
+        assert "from pyspark.sql import DataFrame" in resolved
+        assert {"DataFrame", "F"} <= _bound_names(resolved)
+
+    def test_types_alias_survives_types_wildcard(self):
+        resolved = _resolve(
+            "from pyspark.sql import types as T",
+            "from pyspark.sql.types import *",
+        )
+
+        assert "T" in _bound_names(resolved)
+
+
+class TestSoundCollapsesStillHappen:
+    """The one sound rule — same-module wildcard beats same-module names — stays."""
+
+    def test_same_module_wildcard_beats_specific_names(self):
+        resolved = _resolve(
+            "from pyspark.sql.functions import col, lit",
+            "from pyspark.sql.functions import *",
+        )
+
+        assert resolved == ["from pyspark.sql.functions import *"]
+
+    def test_unrelated_imports_untouched(self):
+        resolved = _resolve(
+            "import os",
+            "from pyspark import pipelines as dp",
+            "from pyspark.sql.functions import *",
+        )
+
+        assert set(resolved) == {
+            "import os",
+            "from pyspark import pipelines as dp",
+            "from pyspark.sql.functions import *",
+        }

--- a/tests/test_base_generator_import_manager.py
+++ b/tests/test_base_generator_import_manager.py
@@ -155,19 +155,25 @@ class TestBaseActionGeneratorRealWorldIntegration:
         assert len(imports) >= 2
 
     def test_real_import_manager_conflict_resolution(self):
-        """Test import conflict resolution with real ImportManager."""
+        """Test import conflict resolution with real ImportManager.
+
+        The wildcard subsumes ``col`` from its own module, so that line
+        collapses. It does not bind ``F``, so the parent ``pyspark.sql`` import
+        survives alongside it.
+        """
         generator = ConcreteBaseActionGenerator(use_import_manager=True)
 
         generator.add_import("from pyspark.sql import functions as F")
+        generator.add_import("from pyspark.sql.functions import col")
         generator.add_import("from pyspark.sql.functions import *")
 
         imports = generator.imports
 
-        # Wildcard takes precedence; F alias removed due to conflict.
         assert "from pyspark.sql.functions import *" in imports
         assert not any(
-            "from pyspark.sql import functions as F" in imp for imp in imports
+            "from pyspark.sql.functions import col" in imp for imp in imports
         )
+        assert any("from pyspark.sql import functions as F" in imp for imp in imports)
 
 
 class TestBaseActionGeneratorEdgeCases:

--- a/tests/test_import_manager.py
+++ b/tests/test_import_manager.py
@@ -114,16 +114,17 @@ class TestConflictResolution:
         assert "from pyspark.sql.functions import col, lit" not in imports
         assert len([imp for imp in imports if "pyspark.sql.functions" in imp]) == 1
 
-    def test_submodule_conflict_resolution(self):
+    def test_submodule_wildcard_keeps_parent_import(self):
+        """A submodule wildcard binds none of the names a parent import binds."""
         self.manager.add_import("from pyspark.sql import functions as F")
         self.manager.add_import("from pyspark.sql.functions import *")
 
         imports = self.manager.get_consolidated_imports()
 
         assert "from pyspark.sql.functions import *" in imports
-        assert "from pyspark.sql import functions as F" not in imports
+        assert "from pyspark.sql import functions as F" in imports
 
-    def test_multiple_submodule_conflicts(self):
+    def test_multiple_submodule_wildcards_keep_their_parents(self):
         self.manager.add_import("from pyspark.sql import functions as F")
         self.manager.add_import("from pyspark.sql import types as T")
         self.manager.add_import("from pyspark.sql.functions import *")
@@ -133,8 +134,8 @@ class TestConflictResolution:
 
         assert "from pyspark.sql.functions import *" in imports
         assert "from pyspark.sql.types import *" in imports
-        assert "from pyspark.sql import functions as F" not in imports
-        assert "from pyspark.sql import types as T" not in imports
+        assert "from pyspark.sql import functions as F" in imports
+        assert "from pyspark.sql import types as T" in imports
 
     def test_non_conflicting_submodules(self):
         self.manager.add_import("from pyspark.sql import SparkSession")
@@ -187,15 +188,13 @@ class TestConflictResolution:
         assert len(imports) == 4
 
     def test_partial_conflicts(self):
-        self.manager.add_import("import os")  # No conflict
-        self.manager.add_import(
-            "from pyspark.sql import functions as F"
-        )  # Will conflict
-        self.manager.add_import("from pathlib import Path")  # No conflict
-        self.manager.add_import(
-            "from pyspark.sql.functions import *"
-        )  # Conflicts with F import
-        self.manager.add_import("from pyspark import pipelines as dp")  # No conflict
+        """A mixed set: only same-module wildcard-vs-specific collapses."""
+        self.manager.add_import("import os")
+        self.manager.add_import("from pyspark.sql import functions as F")
+        self.manager.add_import("from pathlib import Path")
+        self.manager.add_import("from pyspark.sql.functions import col")
+        self.manager.add_import("from pyspark.sql.functions import *")
+        self.manager.add_import("from pyspark import pipelines as dp")
 
         imports = self.manager.get_consolidated_imports()
 
@@ -203,9 +202,13 @@ class TestConflictResolution:
         assert "from pathlib import Path" in imports
         assert "from pyspark import pipelines as dp" in imports
         assert "from pyspark.sql.functions import *" in imports
-        assert "from pyspark.sql import functions as F" not in imports
+        # Same module as the wildcard, which binds 'col' too — collapsed.
+        assert "from pyspark.sql.functions import col" not in imports
+        # A different module from the wildcard's — kept, it binds 'F'.
+        assert "from pyspark.sql import functions as F" in imports
 
     def test_different_alias_patterns(self):
+        """Every parent-import form survives; each binds a distinct name."""
         self.manager.add_import("from pyspark.sql import functions as F")
         self.manager.add_import(
             "from pyspark.sql import functions as pyspark_functions"
@@ -216,11 +219,10 @@ class TestConflictResolution:
         imports = self.manager.get_consolidated_imports()
 
         assert "from pyspark.sql.functions import *" in imports
-        assert not any(
-            "from pyspark.sql import functions" in imp
-            for imp in imports
-            if "import *" not in imp
-        )
+        assert "from pyspark.sql import functions as F" in imports
+        assert "from pyspark.sql import functions as pyspark_functions" in imports
+        # The unaliased form binds 'functions', which the wildcard also lacks.
+        assert "from pyspark.sql import functions" in imports
 
 
 class TestImportSorting:
@@ -653,7 +655,8 @@ class TestRealWorldScenarios:
         ]
 
         assert len(wildcard_imports) == 1
-        assert len(f_alias_imports) == 0
+        # The detected F. expressions need the alias; the wildcard cannot supply it.
+        assert len(f_alias_imports) == 1
 
     def test_operational_metadata_integration(self):
         metadata_expressions = [

--- a/tests/test_orchestrator_include_tests.py
+++ b/tests/test_orchestrator_include_tests.py
@@ -195,6 +195,51 @@ project:
         assert "TARGET TABLES" in result_with
         assert "DATA QUALITY TESTS" in result_with
 
+    def test_test_action_does_not_strip_the_F_alias_other_actions_need(self):
+        """A TEST action must not cost the module its ``functions as F`` binding.
+
+        Test generators contribute ``from pyspark.sql.functions import *`` while
+        an ``F.``-emitting action (here an ``operational_metadata`` column,
+        ``F.current_timestamp()``) contributes ``from pyspark.sql import
+        functions as F``. The two arrive from separate per-generator import
+        managers and are unioned in ``CodeAssembler.assemble``; the resolver
+        used to drop the alias there, leaving ``F.`` unbound (issue #217).
+        """
+        from lhp.core.processing.substitution import EnhancedSubstitutionManager
+
+        flowgroup = FlowGroup(
+            pipeline="alias_pipeline",
+            flowgroup="alias_flowgroup",
+            actions=[
+                Action(
+                    name="load_data",
+                    type=ActionType.LOAD,
+                    source={"type": "sql", "sql": "SELECT 1 as id"},
+                    target="v_data",
+                    operational_metadata=["_ingestion_timestamp"],
+                ),
+                Action(
+                    name="test_data",
+                    type=ActionType.TEST,
+                    test_type="uniqueness",
+                    source="v_data",
+                    columns=["id"],
+                ),
+            ],
+        )
+
+        substitution_mgr = EnhancedSubstitutionManager(
+            self.test_dir / "substitutions" / "test.yaml", "test"
+        )
+
+        result = self.orchestrator.codegen.generate(
+            flowgroup, substitution_mgr, include_tests=True
+        )
+
+        assert "F.current_timestamp()" in result
+        assert "from pyspark.sql import functions as F" in result
+        assert "from pyspark.sql.functions import *" in result
+
     def test_test_only_flowgroup_behavior(self):
         """Test that test-only flowgroups are skipped entirely when include_tests=False."""
         from lhp.core.processing.substitution import EnhancedSubstitutionManager


### PR DESCRIPTION
Fixes #217.

## Root cause

`src/lhp/core/codegen/imports/resolver.py` carried a "rule #2": a submodule wildcard (`from pyspark.sql.functions import *`, contributed by every test generator via `generators/test/_base.py`) superseded the parent-module import (`from pyspark.sql import functions as F`). A wildcard binds neither `F` nor `functions`, so the rule was unsound in every form, not only the aliased one. Worse, the exclusion was applied at module-group granularity, so sibling imports such as `from pyspark.sql import DataFrame` were dropped too.

Any generator emitting `F.` was a trigger: `transform_type: schema`, `operational_metadata` columns (`F.current_timestamp()`), custom sinks. The test action was the only discriminator, exactly as the reporter's follow-up measured. The `operational_metadata` guard the reporter pointed at never sees the wildcard because each generator owns its own `ImportManager`; the sets are only unioned later in `CodeAssembler.assemble`.

## Change

- Rule #2 and its helpers removed; `resolver.py` 138 → 84 lines. Rule #1 (same-module wildcard supersedes that module's specific-name imports) unchanged. Injected callables annotated. Docstring states the surviving rule and why the other was removed.
- The 6 unit tests that asserted the old behaviour now assert the correct one (two renamed where the old name asserted the bug's premise; two given a real `col` import so a genuine same-module collapse is still exercised).
- New `tests/core/codegen/imports/test_resolver_alias_binding.py`: asserts on actual Python binding semantics (AST-derived bound names), including the `DataFrame` collateral case.
- New integration test in `tests/test_orchestrator_include_tests.py` at the assembler layer: a real flowgroup with an `operational_metadata` column plus a `uniqueness` test, generated with `include_tests=True`, must keep `from pyspark.sql import functions as F`. Verified to fail if rule #2 is re-injected.
- CHANGELOG `### Fixed` entry.

## Verification

- 88 resolver/assembler tests pass; full non-e2e suite 5372 passed (`tests/webapp` excluded: pre-existing collection errors at HEAD).
- Full e2e 196 passed with **no file under `tests/e2e/` changed**; the fixture project regenerated with and without `--include-tests` is byte-identical to the committed baselines (the fixture keeps test actions in test-only flowgroups, which is why this shipped undetected).
- Three reproduction projects (schema transform, operational_metadata only, materialized view) now bind `F` and keep `DataFrame`.
- ruff, mypy on the touched module, file-size, placement, stability-drift, import-linter: all clean. Independent constitution review: no blockers; its should-fix items (test naming/docstring accuracy, assembler-layer coverage) are applied.

## Deferred (owner decisions, not in this PR)

- The test templates' `from pyspark.sql.functions import *` is now provably unused (no test template body references a bare function name). Removing it would move 8 e2e baselines and a docs fixture.
- `core/codegen/operational_metadata/metadata.py`'s wildcard-adaptation path is unreachable in production (per-generator import managers). Deleting it means deleting its unit test.
- The reporter's proposed post-generate "every `F.`-referencing module binds `F`" check belongs in `assert_generated_python_valid` as its own change.